### PR TITLE
Move CODEOWNERS to .github directory

### DIFF
--- a/.github/ISSUE_TEMPLATE/CODEOWNERS
+++ b/.github/ISSUE_TEMPLATE/CODEOWNERS
@@ -1,0 +1,17 @@
+# Code owners for M365-Security-Frameworks
+# Every PR automatically requests review from the listed owner(s).
+# Syntax: <path-pattern> <owner> [additional owners]
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+*                                           @dmorgan-chc
+
+# Framework ownership
+/Frameworks/Conditional-Access-Baseline/    @dmorgan-chc
+/Scripts/                                   @dmorgan-chc
+
+# Repo governance
+/.github/                                   @dmorgan-chc
+/README.md                                  @dmorgan-chc
+/CHANGELOG.md                               @dmorgan-chc
+/LICENSE                                    @dmorgan-chc


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what changes and why. -->
Moving CODEOWNERS file to a different folder.

## Type of change

- [ ] Bug fix (script, template, or doc)
- [ ] New policy template
- [ ] Change to existing policy template
- [ ] Documentation
- [x] Tooling / repo hygiene

## Design principle cited

<!-- If this is a policy change, cite the principle from Policy-Design.md it serves. -->
None

## Checklist

- [ ] Policy changes include a report-only deployment step and rollout notes.
- [ ] Placeholders use the `REPLACE_WITH_*_OBJECT_ID` / `REPLACE_WITH_*_STRENGTH_ID` convention.
- [ ] No tenant-specific IDs, user principal names, or internal URLs committed.
- [ ] `Deploy-CABaseline.ps1 -WhatIf` still parses every template without error.
- [ ] CHANGELOG.md updated under `## [Unreleased]`.
- [ ] Docs updated if behavior, required scopes, or prerequisites changed.
- [ ] markdownlint clean (or justified exemption in `.markdownlint.json`).

## Test evidence
None
<!-- WhatIf output, screenshot, or tenant result. Redact identifiers. -->