### PR TITLE
Add Get-CABaselineImpact.ps1 report-only telemetry tool

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,5 +4,6 @@
   "MD033": false,
   "MD041": false,
   "MD040": false,
+  "MD024": false,
   "MD060": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Planned for v1.1 of the **Conditional Access Baseline**:
+### Added
+
+- Scripts/Get-CABaselineImpact.ps1 — report-only telemetry tool: analyzes sign-in logs and summarizes what each report-only CA policy would have done if enforced.
+- Scripts/README.md — documentation and promotion rubric for Get-CABaselineImpact.ps1.
+- .github/ISSUE_TEMPLATE/ — bug report, policy request, and documentation fix issue templates.
+- .github/pull_request_template.md — PR checklist aligned to the four design principles.
+- .github/CODEOWNERS — auto-review routing on every PR.
+
+### Planned for v1.1 of the **Conditional Access Baseline**
 
 - Repo hygiene: issue templates, PR template, `CODEOWNERS`, GitHub Project board
 - Report-only telemetry script to quantify impact before enforcement

--- a/Frameworks/Conditional-Access-Baseline/Scripts/Get-CABaselineImpact.ps1
+++ b/Frameworks/Conditional-Access-Baseline/Scripts/Get-CABaselineImpact.ps1
@@ -1,0 +1,212 @@
+<#
+.SYNOPSIS
+    Analyzes sign-in logs to report the impact of report-only Conditional Access policies.
+
+.DESCRIPTION
+    Get-CABaselineImpact.ps1 pulls Entra sign-in logs over a configurable window and
+    summarizes what each report-only CA policy would have done if enforced. Helps
+    validate the baseline before promoting policies to enabled state.
+
+    Report outcomes:
+    - Would have blocked       (reportOnlyFailure)     — grant controls would have failed the sign-in
+    - Would have challenged    (reportOnlyInterrupted) — user would have been prompted (MFA, auth strength)
+    - Would have passed        (reportOnlySuccess)     — grant controls already satisfied
+    - Not applied              (reportOnlyNotApplied)  — conditions didn't match
+
+.PARAMETER Days
+    Look-back window in days. Default: 7. Max practical: 30 (Graph retention limit on most tenants).
+
+.PARAMETER StartDate
+    Explicit start datetime (ISO 8601). Overrides -Days if provided.
+
+.PARAMETER EndDate
+    Explicit end datetime (ISO 8601). Defaults to now.
+
+.PARAMETER PolicyNameFilter
+    Optional substring to filter policies by display name. Default: 'CA-' (matches the baseline).
+
+.PARAMETER ExportCsvPath
+    Optional path to export per-sign-in policy evaluations as CSV.
+
+.EXAMPLE
+    .\Get-CABaselineImpact.ps1
+    Summarize the last 7 days of CA- policy evaluations.
+
+.EXAMPLE
+    .\Get-CABaselineImpact.ps1 -Days 14 -ExportCsvPath .\impact.csv
+    Two-week window with CSV export for pivoting in Excel.
+
+.EXAMPLE
+    .\Get-CABaselineImpact.ps1 -PolicyNameFilter 'CA-COV'
+    Only evaluate coverage-pillar policies.
+
+.NOTES
+    Requires:
+    - PowerShell 7.0 or later
+    - Microsoft.Graph PowerShell SDK 2.x
+    - Graph scopes: AuditLog.Read.All, Directory.Read.All, Policy.Read.All
+
+    Connect with:
+      Connect-MgGraph -Scopes AuditLog.Read.All,Directory.Read.All,Policy.Read.All
+
+    Author: Derek Morgan, Cloud Harbor Consulting
+    Repository: https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()][int]$Days = 7,
+    [Parameter()][datetime]$StartDate,
+    [Parameter()][datetime]$EndDate = (Get-Date),
+    [Parameter()][string]$PolicyNameFilter = 'CA-',
+    [Parameter()][string]$ExportCsvPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+#region Helpers
+
+function Write-Status {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Message,
+        [ValidateSet('Info', 'Success', 'Warning', 'Error')][string]$Level = 'Info'
+    )
+    $color = switch ($Level) {
+        'Success' { 'Green' }
+        'Warning' { 'Yellow' }
+        'Error'   { 'Red' }
+        default   { 'Cyan' }
+    }
+    $prefix = switch ($Level) {
+        'Success' { '[OK]   ' }
+        'Warning' { '[WARN] ' }
+        'Error'   { '[ERR]  ' }
+        default   { '[INFO] ' }
+    }
+    Write-Host "$prefix$Message" -ForegroundColor $color
+}
+
+function Test-GraphPrerequisites {
+    if (-not (Get-Module -ListAvailable -Name 'Microsoft.Graph.Authentication')) {
+        throw "Microsoft.Graph PowerShell SDK is not installed. Run: Install-Module Microsoft.Graph -Scope CurrentUser"
+    }
+    $context = Get-MgContext
+    if (-not $context) {
+        throw "Not connected to Microsoft Graph. Run: Connect-MgGraph -Scopes AuditLog.Read.All,Directory.Read.All,Policy.Read.All"
+    }
+    $required = @('AuditLog.Read.All', 'Directory.Read.All', 'Policy.Read.All')
+    $missing = $required | Where-Object { $_ -notin $context.Scopes }
+    if ($missing) {
+        throw "Graph session is missing required scopes: $($missing -join ', '). Reconnect with all required scopes."
+    }
+}
+
+function Get-SignInsInWindow {
+    param(
+        [Parameter(Mandatory)][datetime]$Start,
+        [Parameter(Mandatory)][datetime]$End
+    )
+    $startIso = $Start.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $endIso   = $End.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $filter = "createdDateTime ge $startIso and createdDateTime le $endIso"
+    $encoded = [System.Uri]::EscapeDataString($filter)
+    $uri = "https://graph.microsoft.com/v1.0/auditLogs/signIns?`$filter=$encoded&`$top=1000"
+
+    $all = [System.Collections.Generic.List[object]]::new()
+    $page = 0
+    while ($uri) {
+        $page++
+        Write-Status "  Fetching page $page..."
+        $response = Invoke-MgGraphRequest -Method GET -Uri $uri
+        if ($response.value) { $all.AddRange([object[]]$response.value) }
+        $uri = $response.'@odata.nextLink'
+    }
+    return $all
+}
+
+#endregion
+
+#region Main
+
+try {
+    Write-Status "Get-CABaselineImpact starting"
+    Test-GraphPrerequisites
+    $tenantContext = Get-MgContext
+    Write-Status "Connected tenant: $($tenantContext.TenantId) as $($tenantContext.Account)" -Level Success
+
+    if (-not $StartDate) { $StartDate = $EndDate.AddDays(-$Days) }
+    Write-Status "Window: $($StartDate.ToString('u')) -> $($EndDate.ToString('u'))"
+    Write-Status "Policy filter: displayName contains '$PolicyNameFilter'"
+
+    Write-Status "Fetching sign-in logs..."
+    $signIns = Get-SignInsInWindow -Start $StartDate -End $EndDate
+    Write-Status "Retrieved $($signIns.Count) sign-in events" -Level Success
+
+    $records = foreach ($si in $signIns) {
+        if (-not $si.appliedConditionalAccessPolicies) { continue }
+        foreach ($p in $si.appliedConditionalAccessPolicies) {
+            if ($p.displayName -notlike "*$PolicyNameFilter*") { continue }
+            [pscustomobject]@{
+                SignInId       = $si.id
+                CreatedUtc     = $si.createdDateTime
+                UserPrincipal  = $si.userPrincipalName
+                UserId         = $si.userId
+                AppDisplayName = $si.appDisplayName
+                PolicyId       = $p.id
+                PolicyName     = $p.displayName
+                Result         = $p.result
+            }
+        }
+    }
+
+    if (-not $records) {
+        Write-Status "No policy evaluations matched filter '$PolicyNameFilter' in this window." -Level Warning
+        return
+    }
+
+    Write-Status ""
+    Write-Status "Per-policy impact summary:"
+    $summary = $records | Group-Object PolicyName | ForEach-Object {
+        $group = $_.Group
+        [pscustomobject]@{
+            Policy           = $_.Name
+            Evaluations      = $group.Count
+            UniqueUsers      = ($group.UserPrincipal | Sort-Object -Unique).Count
+            WouldBlock       = @($group | Where-Object { $_.Result -eq 'reportOnlyFailure' }).Count
+            WouldChallenge   = @($group | Where-Object { $_.Result -eq 'reportOnlyInterrupted' }).Count
+            WouldPass        = @($group | Where-Object { $_.Result -eq 'reportOnlySuccess' }).Count
+            NotApplied       = @($group | Where-Object { $_.Result -eq 'reportOnlyNotApplied' }).Count
+        }
+    } | Sort-Object Policy
+
+    $summary | Format-Table -AutoSize
+
+    $affectedByUser = $records |
+        Where-Object { $_.Result -in 'reportOnlyFailure', 'reportOnlyInterrupted' } |
+        Group-Object UserPrincipal |
+        Sort-Object Count -Descending |
+        Select-Object -First 10
+
+    if ($affectedByUser) {
+        Write-Status ""
+        Write-Status "Top 10 users by would-block + would-challenge:"
+        $affectedByUser | ForEach-Object {
+            [pscustomobject]@{ User = $_.Name; Count = $_.Count }
+        } | Format-Table -AutoSize
+    }
+
+    if ($ExportCsvPath) {
+        $records | Export-Csv -Path $ExportCsvPath -NoTypeInformation -Encoding UTF8
+        Write-Status "Exported $($records.Count) records to $ExportCsvPath" -Level Success
+    }
+
+    Write-Status ""
+    Write-Status "Reminder: review would-block spikes before promoting any policy to enabled state." -Level Info
+
+} catch {
+    Write-Status $_ -Level Error
+    exit 1
+}
+
+#endregion

--- a/Frameworks/Conditional-Access-Baseline/Scripts/README.md
+++ b/Frameworks/Conditional-Access-Baseline/Scripts/README.md
@@ -5,10 +5,11 @@ This folder contains deployment automation for the Conditional Access Baseline f
 | Script | Purpose |
 |--------|---------|
 | Deploy-CABaseline.ps1 | Imports the six CA-COV, CA-SIG, and CA-AUT policy templates into a Microsoft Entra tenant. Resolves tenant-specific placeholders at runtime, defaults to report-only state, and supports -WhatIf for safe preview. |
+| Get-CABaselineImpact.ps1 | Analyzes Entra sign-in logs to report what each report-only CA policy would have done if enforced. Use this before promoting any policy from `enabledForReportingButNotEnforced` to `enabled` state. |
 
 ## Prerequisites
 
-Before running any script in this folder, confirm the following are in place in your tenant and on your machine.
+Before running any script in this folder, confirm the following are in place in your tenant and on your machine. Graph scopes differ per script — see each script's section below.
 
 ### On your machine
 
@@ -29,17 +30,19 @@ Before running any script in this folder, confirm the following are in place in 
 - Emergency access accounts are created, documented, monitored by alert, and members of the CA-Persona-EmergencyAccess group only.
 - The built-in Phishing-resistant MFA authentication strength policy exists (this is a default in Entra ID P1+).
 
+## Deploy-CABaseline.ps1
+
 ### Permissions to connect
 
 Connect to Microsoft Graph with all three scopes below before running the script:
 
 ```powershell
-Connect-MgGraph -Scopes Policy.ReadWrite.ConditionalAccess,Group.Read.All,Policy.Read.All
+Connect-MgGraph -Scopes Policy.ReadWrite.ConditionalAccess,Group.Read.All,Policy.Read.All,Application.Read.All
 ```
 
-## Usage
+### Usage
 
-### Preview mode (no changes made)
+#### Preview mode (no changes made)
 
 ```powershell
 .\Deploy-CABaseline.ps1 -WhatIf
@@ -47,7 +50,7 @@ Connect-MgGraph -Scopes Policy.ReadWrite.ConditionalAccess,Group.Read.All,Policy
 
 Runs every read operation — group lookups, authentication strength lookup, template parsing, placeholder substitution — but stops before creating any policy. Use this the first time you run the script to validate that all placeholders resolve cleanly in your tenant.
 
-### Report-only deployment (default, safe)
+#### Report-only deployment (default, safe)
 
 ```powershell
 .\Deploy-CABaseline.ps1
@@ -55,7 +58,7 @@ Runs every read operation — group lookups, authentication strength lookup, tem
 
 Creates all six policies in enabledForReportingButNotEnforced state. Policies evaluate every sign-in and log the outcome, but never block or challenge a user. This is the safe default for every first deployment.
 
-### Enforced deployment (destructive, requires confirmation)
+#### Enforced deployment (destructive, requires confirmation)
 
 ```powershell
 .\Deploy-CABaseline.ps1 -Enforce
@@ -67,7 +70,7 @@ Creates all six policies in enabled state. Prompts once for confirmation before 
 2. Validation that every user in scope has the prerequisites for each policy (MFA registration for CA-COV002, phishing-resistant credentials for CA-AUT001/002, device compliance for CA-SIG001).
 3. Review and tuning of Entra ID Protection risk detections for CA-SIG002.
 
-### Custom persona group names
+#### Custom persona group names
 
 If your tenant uses different display names for the persona groups, override them via parameters:
 
@@ -77,7 +80,7 @@ If your tenant uses different display names for the persona groups, override the
 
 See the script's comment-based help (`Get-Help .\Deploy-CABaseline.ps1 -Full`) for the complete parameter list.
 
-## Expected output
+### Expected output
 
 Successful report-only deployment produces output similar to:
 
@@ -99,9 +102,9 @@ Successful report-only deployment produces output similar to:
 [INFO] Reminder: Policies are in report-only mode. Soak, validate, and promote to enforced per Policy-Design.md section 5.
 ```
 
-## Troubleshooting
+### Troubleshooting
 
-### "Group not found in tenant"
+#### "Group not found in tenant"
 
 One of the persona groups does not exist or is named differently. Verify with:
 
@@ -111,7 +114,7 @@ Get-MgGroup -Filter "displayName eq 'CA-Persona-EmergencyAccess'"
 
 Create the missing group or override the parameter with your tenant's actual group name.
 
-### "Authentication strength not found"
+#### "Authentication strength not found"
 
 The built-in Phishing-resistant MFA authentication strength is missing or has been renamed. Verify with:
 
@@ -121,20 +124,111 @@ Invoke-MgGraphRequest GET 'https://graph.microsoft.com/v1.0/identity/conditional
 
 If the built-in is renamed in your tenant, pass the custom name via -AuthStrengthName.
 
-### "Not connected to Microsoft Graph"
+#### "Not connected to Microsoft Graph"
 
 Run Connect-MgGraph with the three required scopes listed above. A session with fewer scopes will be rejected with a clear error.
 
-### "Unresolved placeholders remain"
+#### "Unresolved placeholders remain"
 
 A JSON template contains a REPLACE_WITH_ token that the script does not know how to substitute. Open an issue in the repo with the template name — this indicates a bug in the substitution map.
 
-### A policy import fails mid-run
+#### A policy import fails mid-run
 
 Per-policy errors do not cascade. The script logs the failure, continues to the next template, and produces a summary table at the end. Re-run after fixing the underlying issue — successfully created policies will attempt to be re-created and fail with a duplicate-name error, which is safe. If you want to retry from a clean state, delete the successful policies in Entra first.
+
+## Get-CABaselineImpact.ps1
+
+### Permissions to connect
+
+Connect to Microsoft Graph with all three scopes below before running the script:
+
+```powershell
+Connect-MgGraph -Scopes AuditLog.Read.All,Directory.Read.All,Policy.Read.All
+```
+
+### Usage
+
+#### Default — last 7 days, all CA-* policies
+
+```powershell
+.\Get-CABaselineImpact.ps1
+```
+
+Pulls sign-in logs for the last seven days and summarizes the impact of every policy whose display name contains `CA-`.
+
+#### Custom window with CSV export
+
+```powershell
+.\Get-CABaselineImpact.ps1 -Days 14 -ExportCsvPath .\impact.csv
+```
+
+Two-week window. Writes one row per (sign-in, policy) evaluation to `impact.csv` for pivoting in Excel.
+
+#### Filter to a specific pillar
+
+```powershell
+.\Get-CABaselineImpact.ps1 -PolicyNameFilter 'CA-COV'
+```
+
+Only evaluates coverage-pillar policies. Swap for `CA-SIG` or `CA-AUT` to target the other pillars.
+
+#### Explicit start and end dates
+
+```powershell
+.\Get-CABaselineImpact.ps1 -StartDate '2026-04-01' -EndDate '2026-04-15'
+```
+
+Overrides -Days with an explicit window. Useful for retrospective analysis or reproducing a prior report.
+
+### Output
+
+Per-policy summary table with:
+
+- **Evaluations** — total times the policy was evaluated in the window
+- **UniqueUsers** — distinct users affected
+- **WouldBlock** — `reportOnlyFailure` count (grant controls would have failed)
+- **WouldChallenge** — `reportOnlyInterrupted` count (user would have been prompted — MFA, auth strength)
+- **WouldPass** — `reportOnlySuccess` count (user already satisfied grant controls)
+- **NotApplied** — conditions did not match the sign-in
+
+Followed by a top-10 list of users by would-block + would-challenge count — useful for identifying accounts that need remediation (enroll MFA, join device to Entra, etc.) before enforcement.
+
+### Promotion rubric
+
+Before promoting a policy from report-only to enabled state:
+
+1. Run with `-Days 14` to get a full two-week sample.
+2. Confirm **WouldBlock + WouldChallenge** affects only the expected personas.
+3. For each unique user in the top-10 list, confirm they can satisfy the grant controls (MFA registered, device compliant, etc.).
+4. Communicate the enforcement date to affected users if the count is non-trivial.
+5. Promote the policy and re-run 24 hours later to confirm the enforced result matches the report-only prediction.
+
+### Troubleshooting
+
+#### "No policy evaluations matched filter"
+
+Either the tenant has no sign-ins matching the filter in the window, or the policies haven't been deployed yet. Verify with:
+
+```powershell
+Get-MgIdentityConditionalAccessPolicy | Where-Object { $_.DisplayName -like 'CA-*' } | Select-Object DisplayName, State
+```
+
+If policies are deployed but the window is quiet, widen it with `-Days 30`.
+
+#### "Not connected to Microsoft Graph" or "missing required scopes"
+
+Run Connect-MgGraph with the three required scopes listed above. A session with fewer scopes will be rejected with a clear error.
+
+#### Slow runs on large tenants
+
+Sign-in log pagination handles page sizes up to 1000 events. Tenants with hundreds of thousands of daily sign-ins can take several minutes. Narrow the window with `-Days` or a specific `-StartDate` / `-EndDate` if needed.
+
+#### CSV export is empty
+
+If no sign-ins matched the filter, no records are written. Check the per-policy summary first — if every count is zero, there's nothing to export.
 
 ## Reference
 
 - Policy-Design.md — baseline philosophy, naming convention, persona model, rollout sequence
-- Policies/ — the six JSON policy templates consumed by this script
+- Policies/ — the six JSON policy templates consumed by Deploy-CABaseline.ps1
 - Repo root README — framework overview and business-case positioning


### PR DESCRIPTION
## Summary

Added Get-CABaselineImpact.ps1 and modified the following files: Scripts/README.md, CHANGELOG.md, and .markdownlint.json

## Type of change

- [ ] Bug fix (script, template, or doc)
- [ ] New policy template
- [ ] Change to existing policy template
- [ ] Documentation
- [x] Tooling / repo hygiene

## Design principle cited

<!-- If this is a policy change, cite the principle from Policy-Design.md it serves. -->

## Checklist

- [ ] Policy changes include a report-only deployment step and rollout notes.
- [ ] Placeholders use the `REPLACE_WITH_*_OBJECT_ID` / `REPLACE_WITH_*_STRENGTH_ID` convention.
- [ ] No tenant-specific IDs, user principal names, or internal URLs committed.
- [ ] `Deploy-CABaseline.ps1 -WhatIf` still parses every template without error.
- [ ] CHANGELOG.md updated under `## [Unreleased]`.
- [ ] Docs updated if behavior, required scopes, or prerequisites changed.
- [ ] markdownlint clean (or justified exemption in `.markdownlint.json`).

## Test evidence

None