### PR TITLE
Get-CABaselineImpact.ps1 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .github/pull_request_template.md — PR checklist aligned to the four design principles.
 - .github/CODEOWNERS — auto-review routing on every PR.
 
+### Fixed
+
+- Get-CABaselineImpact.ps1 — StrictMode-safe check for `@odata.nextLink` so the script doesn't error on the final page of sign-in results.
+- Get-CABaselineImpact.ps1 — force array semantics around `.Count` accesses so the script works when 0 or 1 sign-ins / records / unique users exist (StrictMode correctness).
+
 ### Planned for v1.1 of the **Conditional Access Baseline**
 
 - Repo hygiene: issue templates, PR template, `CODEOWNERS`, GitHub Project board

--- a/Frameworks/Conditional-Access-Baseline/Scripts/Get-CABaselineImpact.ps1
+++ b/Frameworks/Conditional-Access-Baseline/Scripts/Get-CABaselineImpact.ps1
@@ -120,7 +120,7 @@ function Get-SignInsInWindow {
         Write-Status "  Fetching page $page..."
         $response = Invoke-MgGraphRequest -Method GET -Uri $uri
         if ($response.value) { $all.AddRange([object[]]$response.value) }
-        $uri = $response.'@odata.nextLink'
+        $uri = if ($response.ContainsKey('@odata.nextLink')) { $response['@odata.nextLink'] } else { $null }
     }
     return $all
 }
@@ -140,10 +140,10 @@ try {
     Write-Status "Policy filter: displayName contains '$PolicyNameFilter'"
 
     Write-Status "Fetching sign-in logs..."
-    $signIns = Get-SignInsInWindow -Start $StartDate -End $EndDate
+    $signIns = @(Get-SignInsInWindow -Start $StartDate -End $EndDate)
     Write-Status "Retrieved $($signIns.Count) sign-in events" -Level Success
 
-    $records = foreach ($si in $signIns) {
+    $records = @(foreach ($si in $signIns) {
         if (-not $si.appliedConditionalAccessPolicies) { continue }
         foreach ($p in $si.appliedConditionalAccessPolicies) {
             if ($p.displayName -notlike "*$PolicyNameFilter*") { continue }
@@ -158,8 +158,8 @@ try {
                 Result         = $p.result
             }
         }
-    }
-
+    })
+    
     if (-not $records) {
         Write-Status "No policy evaluations matched filter '$PolicyNameFilter' in this window." -Level Warning
         return
@@ -172,7 +172,7 @@ try {
         [pscustomobject]@{
             Policy           = $_.Name
             Evaluations      = $group.Count
-            UniqueUsers      = ($group.UserPrincipal | Sort-Object -Unique).Count
+            UniqueUsers      = @($group.UserPrincipal | Sort-Object -Unique).Count
             WouldBlock       = @($group | Where-Object { $_.Result -eq 'reportOnlyFailure' }).Count
             WouldChallenge   = @($group | Where-Object { $_.Result -eq 'reportOnlyInterrupted' }).Count
             WouldPass        = @($group | Where-Object { $_.Result -eq 'reportOnlySuccess' }).Count


### PR DESCRIPTION
## Summary
Get-CABaselineImpact: handle missing @odata.nextLink and force array semantics for .Count under StrictMode

<!-- One or two sentences: what changes and why. -->

## Type of change

- [x] Bug fix (script, template, or doc)
- [ ] New policy template
- [ ] Change to existing policy template
- [ ] Documentation
- [ ] Tooling / repo hygiene

## Design principle cited

<!-- If this is a policy change, cite the principle from Policy-Design.md it serves. -->

## Checklist

- [ ] Policy changes include a report-only deployment step and rollout notes.
- [ ] Placeholders use the `REPLACE_WITH_*_OBJECT_ID` / `REPLACE_WITH_*_STRENGTH_ID` convention.
- [ ] No tenant-specific IDs, user principal names, or internal URLs committed.
- [ ] `Deploy-CABaseline.ps1 -WhatIf` still parses every template without error.
- [ ] CHANGELOG.md updated under `## [Unreleased]`.
- [ ] Docs updated if behavior, required scopes, or prerequisites changed.
- [ ] markdownlint clean (or justified exemption in `.markdownlint.json`).

## Test evidence

<!-- WhatIf output, screenshot, or tenant result. Redact identifiers. -->