### PR TITLE
Feature/ca cov003 workload identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .github/CODEOWNERS — auto-review routing on every PR.
 - Frameworks/Conditional-Access-Baseline/Policies/CA-EXC001-EmergencyAccess-Exclusion.md — written contract documenting that every CA-* policy excludes the Emergency Access persona, plus the operational runbook (alerting, monthly attestation, quarterly recovery drill, rotation).
 - Frameworks/Conditional-Access-Baseline/Policies/CA-SIG003-Guests-RequireMFA.json — requires MFA for all external users (B2B collaboration guests, direct-connect users, internal guests, service providers, and other external users) on all applications. Honors CA-EXC001 by excluding the Emergency Access persona.
+- Frameworks/Conditional-Access-Baseline/Policies/CA-COV003-WorkloadIdentities-TrustedLocations.json — blocks service principal sign-ins from outside a tenant-defined Trusted IPs named location. Requires Microsoft Entra Workload Identities Premium SKU; CAE does not apply to workload identity tokens.
+- Frameworks/Conditional-Access-Baseline/Policies/CA-COV003-WorkloadIdentities.md — design doc covering hard prerequisites (Workload Identities Premium, Trusted IPs named location), per-SPN exclusion model (distinct from user-targeted CA-EXC001), SPN discovery query, and CAE limitations for workload identities.
 
 ### Fixed
 

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-COV003-WorkloadIdentities-TrustedLocations.json
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-COV003-WorkloadIdentities-TrustedLocations.json
@@ -1,0 +1,22 @@
+{
+    "displayName": "CA-COV003-WorkloadIdentities-TrustedLocations",
+    "state": "enabledForReportingButNotEnforced",
+    "conditions": {
+        "clientApplications": {
+            "includeServicePrincipals": ["ServicePrincipalsInMyTenant"],
+            "excludeServicePrincipals": []
+        },
+        "applications": {
+            "includeApplications": ["All"]
+        },
+        "locations": {
+            "includeLocations": ["All"],
+            "excludeLocations": ["REPLACE_WITH_TRUSTED_IPS_LOCATION_ID"]
+        },
+        "clientAppTypes": ["all"]
+    },
+    "grantControls": {
+        "operator": "OR",
+        "builtInControls": ["block"]
+    }
+}

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-COV003-WorkloadIdentities.md
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-COV003-WorkloadIdentities.md
@@ -1,0 +1,91 @@
+# CA-COV003 — Workload Identities: Trusted Locations Only
+
+Blocks service principal sign-ins from outside a tenant-defined trusted IPs named location. Closes the workload identity gap that user-targeted policies (CA-SIG003, CA-COV001/002) cannot address — service principals do not have user accounts, so MFA and risk-based grant controls do not apply to them.
+
+## Hard prerequisites
+
+This policy will not evaluate without both of the following. The deployer's `-WhatIf` mode will load and lint the JSON either way; **applying past report-only will fail at creation time** if the SKU is missing.
+
+1. **Microsoft Entra Workload Identities Premium** — separate SKU from Entra ID P1/P2. Confirm via [Microsoft Entra admin center → Identity → Overview → Licenses](https://entra.microsoft.com) before applying. Trial activation is available for non-production tenants.
+2. **A Trusted IPs named location** — see "Pre-flight" below.
+
+## Pre-flight: create the Trusted IPs named location
+
+If you do not yet have a named location representing your trusted egress ranges (office, VPN, or remote-worker static IPs), create one first:
+
+1. Microsoft Entra admin center → Protection → Conditional Access → Named locations → **+ IP ranges location**
+2. Name: `Trusted IPs` (or your convention)
+3. Add CIDR ranges representing every egress IP you trust
+4. Mark **Define as trusted location**: Yes
+5. Save, then capture the location's object ID — replace `REPLACE_WITH_TRUSTED_IPS_LOCATION_ID` in `CA-COV003-WorkloadIdentities-TrustedLocations.json` with that ID before deploying
+
+> **Remote-only operators:** if you have no fixed egress, the operational pattern shifts. Either (a) define your residential static IPs as the trusted set and accept the brittleness, (b) defer this policy until a static-egress source exists (cloud bastion, vendor like Cloudflare WARP with dedicated egress), or (c) tighten scope to specific high-risk service principals only. Document which path your tenant takes.
+
+## Scope
+
+| Setting | Value | Rationale |
+|---|---|---|
+| Include service principals | `ServicePrincipalsInMyTenant` | Default-deny model — every SPN inherits the policy unless explicitly excluded |
+| Exclude service principals | tenant-specific | Populate per the discovery query below |
+| Applications | `All` | Workload identity policies do not need per-app scoping; the SPN is the identity being protected |
+| Locations | All except Trusted IPs | Block boundary defined by the named location, not by user attribute |
+| Grant control | `block` | Service principals cannot satisfy MFA or other interactive controls — block is the only meaningful enforcement |
+
+## Exclusion model — read this carefully
+
+CA-EXC001 (the Emergency Access exclusion contract) is **user-only**. It does not apply to CA-COV003 because workload identities are not user objects.
+
+Workload identity exclusions are managed **per-service-principal**, by object ID, in the policy itself — there is no "Emergency Access workload identities" group equivalent. This is by design in the Microsoft Graph schema: `excludeServicePrincipals` accepts SPN object IDs only.
+
+**Exclusion governance pattern:**
+
+- Maintain the exclude list inline in the JSON, with a comment-style commit message explaining each addition (PR description, since JSON does not support comments)
+- Re-attest the exclude list quarterly alongside CA-EXC001's recovery drill
+- Any addition to the exclude list requires a paired GitHub issue documenting the SPN, owner, and reason for exemption
+
+## Discovery: finding SPNs that may need exclusion
+
+Run this against the tenant before applying the policy past report-only. Any SPN that signed in from outside the trusted location in the last 30 days will be blocked once enforced — review and decide per-SPN whether to exclude or to fix the egress.
+
+```powershell
+Connect-MgGraph -Scopes "AuditLog.Read.All","Application.Read.All"
+
+$start = (Get-Date).AddDays(-30).ToString('yyyy-MM-ddTHH:mm:ssZ')
+$filter = "createdDateTime ge $start and signInEventTypes/any(t:t eq 'servicePrincipal')"
+$signIns = Get-MgAuditLogSignIn -Filter $filter -All
+
+$signIns |
+    Group-Object ServicePrincipalName, IpAddress |
+    Sort-Object Count -Descending |
+    Select-Object Count,
+        @{N='ServicePrincipal';E={$_.Group[0].ServicePrincipalName}},
+        @{N='SPNObjectId';E={$_.Group[0].ServicePrincipalId}},
+        @{N='SourceIP';E={$_.Group[0].IpAddress}} |
+    Format-Table -AutoSize
+```
+
+Cross-reference the `SourceIP` column against the trusted IPs ranges. SPNs signing in from non-trusted IPs are candidates for either exclusion (if legitimately remote, e.g., Microsoft first-party connectors with dynamic egress) or remediation (route through trusted egress).
+
+## Continuous Access Evaluation — does not apply
+
+CAE is a user-token feature. Workload identity tokens are **not** subject to CAE re-evaluation. If a service principal token is issued and the SPN is later compromised, revocation requires:
+
+1. Disabling the SPN in Entra (`Update-MgServicePrincipal -ServicePrincipalId <id> -AccountEnabled:$false`), or
+2. Rotating the SPN's credentials (cert/secret rollover), or
+3. Adding the SPN object ID to a block-targeted CA policy and waiting for the existing token's natural expiry
+
+Do not assume CA-COV003 provides the same fast-revocation guarantees that CAE-aware user policies do.
+
+## Validation (after policy ships in report-only)
+
+```powershell
+.\Scripts\Get-CABaselineImpact.ps1 -PolicyNameFilter 'CA-COV003' -Days 7
+```
+
+Expected pattern in a healthy tenant:
+
+- `WouldBlock` — SPNs signing in from non-trusted IPs. Investigate each one before enforcing.
+- `WouldPass` — SPNs signing in from trusted IPs. Working as intended.
+- `NotApplied` — entries for SPNs in the `excludeServicePrincipals` list, plus all user sign-ins (workload identity policies do not target users).
+
+If `WouldBlock` includes Microsoft first-party SPNs (Microsoft Graph, Exchange Online, etc.), do **not** add them to the exclude list — investigate why a first-party SPN is appearing in your tenant's sign-in logs before changing the policy.

--- a/Frameworks/Conditional-Access-Baseline/README.md
+++ b/Frameworks/Conditional-Access-Baseline/README.md
@@ -1,6 +1,6 @@
 # Conditional Access Baseline
 
-A defensible Conditional Access baseline for Microsoft Entra ID — seven starter policies that enforce Zero Trust access principles, grounded in the risk-reduction framing published in [Why Entra ID Conditional Access Fails in Practice (And How to Fix It)](https://www.cloudharborconsulting.cloud/post/why-entra-id-conditional-access-fails-in-practice-and-how-to-fix-it).
+A defensible Conditional Access baseline for Microsoft Entra ID — eight starter policies that enforce Zero Trust access principles, grounded in the risk-reduction framing published in [Why Entra ID Conditional Access Fails in Practice (And How to Fix It)](https://www.cloudharborconsulting.cloud/post/why-entra-id-conditional-access-fails-in-practice-and-how-to-fix-it).
 
 **Status:** 🟢 Released — v1.0.0
 
@@ -34,7 +34,7 @@ CA-[PrinciplePrefix][Number]-[Persona]-[Action]
 
 **Why this convention:** Every policy name is a micro-reminder of which principle it supports. Admins reading the policy list in Entra see the baseline's thesis reflected in the names themselves, and auditors can trace any policy back to a documented principle in three letters.
 
-## The seven starter policies
+## The eight starter policies
 
 | Policy Name | Purpose |
 |-------------|---------|
@@ -45,6 +45,7 @@ CA-[PrinciplePrefix][Number]-[Persona]-[Action]
 | `CA-AUT002-PrivRoles-RequirePhishResistantMFA` | Enforces strong auth at the role-activation layer (PIM path) |
 | `CA-SIG002-AllUsers-RequireStepUpOnRisk` | Responds dynamically to Entra ID Protection signals on medium/high-risk sign-ins |
 | `CA-SIG003-Guests-RequireMFA` | Requires MFA for all external users — B2B collaboration guests, direct-connect users, internal guests, service providers, and other external user types |
+| `CA-COV003-WorkloadIdentities-TrustedLocations` | Blocks service principal sign-ins from outside the tenant's Trusted IPs named location. Requires Workload Identities Premium SKU |
 
 Environments operating beyond this baseline should layer **Continuous Access Evaluation (CAE)** and **Token Protection** to close the session-token gap that static Conditional Access policies leave open.
 
@@ -53,7 +54,7 @@ Environments operating beyond this baseline should layer **Continuous Access Eva
 | Artifact | Purpose | Status |
 |----------|---------|--------|
 | [Policy design doc](./Design/POLICY-DESIGN.md) | Baseline philosophy, naming convention, exclusion-group strategy | 🟢 Released |
-| [JSON policy templates](./Policies/) | The seven importable Conditional Access policies | 🟢 Released |
+| [JSON policy templates](./Policies/) | The eight importable Conditional Access policies | 🟢 Released |
 | [Deployment scripts](./Scripts/) | PowerShell automation via Microsoft Graph | 🟢 Released |
 | [Business case](./Business-Case/ROI-CONDITIONAL-ACCESS.md) | ROI, risk reduction, and audit framing | 🟢 Released |
 
@@ -96,7 +97,7 @@ This baseline is deployed around the people it protects, not around individual t
 ### v1.0 — Foundation (shipped)
 
 - [x] Publish policy design doc (persona model, naming convention, exclusion strategy)
-- [x] Publish seven core JSON policy templates
+- [x] Publish eight core JSON policy templates
 - [x] Publish `Deploy-CABaseline.ps1` with `-WhatIf` and `-ReportOnly` support
 - [x] Publish ROI / business-case document
 - [x] Tag v1.0.0 release
@@ -108,7 +109,7 @@ This baseline is deployed around the people it protects, not around individual t
 - [x] `Get-CABaselineImpact.ps1` — report-only telemetry summarizer (WouldBlock / WouldChallenge / WouldPass / NotApplied)
 - [x] `CA-EXC001-EmergencyAccess-Exclusion.md` — written exclusion contract with monthly attestation and quarterly recovery drill
 - [x] `CA-SIG003-Guests-RequireMFA.json` — MFA for all external user types, honors CA-EXC001
-- [ ] `CA-COV003-WorkloadIdentities` — service principal targeting with IP filters
+- [x] `CA-COV003-WorkloadIdentities` — service principal targeting with IP filters
 - [ ] Persona / ROI doc rollup + tag v1.1.0
 
 ### v1.2 — Candidates (not committed)

--- a/Frameworks/Conditional-Access-Baseline/Scripts/README.md
+++ b/Frameworks/Conditional-Access-Baseline/Scripts/README.md
@@ -4,7 +4,7 @@ This folder contains deployment automation for the Conditional Access Baseline f
 
 | Script | Purpose |
 |--------|---------|
-| Deploy-CABaseline.ps1 | Imports the seven CA-COV, CA-SIG, and CA-AUT policy templates into a Microsoft Entra tenant. Resolves tenant-specific placeholders at runtime, defaults to report-only state, and supports -WhatIf for safe preview. |
+| Deploy-CABaseline.ps1 | Imports the eight CA-COV, CA-SIG, and CA-AUT policy templates into a Microsoft Entra tenant. Resolves tenant-specific placeholders at runtime, defaults to report-only state, and supports -WhatIf for safe preview. |
 | Get-CABaselineImpact.ps1 | Analyzes Entra sign-in logs to report what each report-only CA policy would have done if enforced. Use this before promoting any policy from `enabledForReportingButNotEnforced` to `enabled` state. |
 
 ## Prerequisites
@@ -56,7 +56,7 @@ Runs every read operation — group lookups, authentication strength lookup, tem
 .\Deploy-CABaseline.ps1
 ```
 
-Creates all seven policies in enabledForReportingButNotEnforced state. Policies evaluate every sign-in and log the outcome, but never block or challenge a user. This is the safe default for every first deployment.
+Creates all eight policies in enabledForReportingButNotEnforced state. Policies evaluate every sign-in and log the outcome, but never block or challenge a user. This is the safe default for every first deployment.
 
 #### Enforced deployment (destructive, requires confirmation)
 
@@ -64,7 +64,7 @@ Creates all seven policies in enabledForReportingButNotEnforced state. Policies 
 .\Deploy-CABaseline.ps1 -Enforce
 ```
 
-Creates all seven policies in enabled state. Prompts once for confirmation before touching the tenant. Only run this after:
+Creates all eight policies in enabled state. Prompts once for confirmation before touching the tenant. Only run this after:
 
 1. A full report-only soak period per Policy-Design.md section 5.
 2. Validation that every user in scope has the prerequisites for each policy (MFA registration for CA-COV002, phishing-resistant credentials for CA-AUT001/002, device compliance for CA-SIG001).
@@ -94,11 +94,11 @@ Successful report-only deployment produces output similar to:
 [OK]     REPLACE_WITH_GLOBAL_ADMINS_GROUP_OBJECT_ID -> <guid>
 [OK]     REPLACE_WITH_INTERNAL_USERS_GROUP_OBJECT_ID -> <guid>
 [OK]     REPLACE_WITH_PHISHING_RESISTANT_MFA_STRENGTH_ID -> <guid>
-[OK]   Found 7 policy templates in ../Policies
+[OK]   Found 8 policy templates in ../Policies
 [INFO] Processing: CA-AUT001-PrivAccounts-RequirePhishResistantMFA.json
 [OK]     Created: CA-AUT001-PrivAccounts-RequirePhishResistantMFA [<guid>]
 ... (one entry per template) ...
-[INFO] Created: 7, Previewed: 0, Errors: 0
+[INFO] Created: 8, Previewed: 0, Errors: 0
 [INFO] Reminder: Policies are in report-only mode. Soak, validate, and promote to enforced per Policy-Design.md section 5.
 ```
 
@@ -230,5 +230,5 @@ If no sign-ins matched the filter, no records are written. Check the per-policy 
 ## Reference
 
 - Policy-Design.md — baseline philosophy, naming convention, persona model, rollout sequence
-- Policies/ — the seven JSON policy templates consumed by Deploy-CABaseline.ps1
+- Policies/ — the eight JSON policy templates consumed by Deploy-CABaseline.ps1
 - Repo root README — framework overview and business-case positioning


### PR DESCRIPTION
## Summary
Add CA-COV003 workload identities trusted-locations policy
<!-- One or two sentences: what changes and why. -->

## Type of change

- [ ] Bug fix (script, template, or doc)
- [x] New policy template
- [ ] Change to existing policy template
- [x] Documentation
- [x] Tooling / repo hygiene

## Design principle cited

<!-- If this is a policy change, cite the principle from Policy-Design.md it serves. -->

## Checklist

- [ ] Policy changes include a report-only deployment step and rollout notes.
- [ ] Placeholders use the `REPLACE_WITH_*_OBJECT_ID` / `REPLACE_WITH_*_STRENGTH_ID` convention.
- [ ] No tenant-specific IDs, user principal names, or internal URLs committed.
- [ ] `Deploy-CABaseline.ps1 -WhatIf` still parses every template without error.
- [ ] CHANGELOG.md updated under `## [Unreleased]`.
- [ ] Docs updated if behavior, required scopes, or prerequisites changed.
- [ ] markdownlint clean (or justified exemption in `.markdownlint.json`).

## Test evidence

<!-- WhatIf output, screenshot, or tenant result. Redact identifiers. -->