### PR TITLE
docs(ca-baseline): document CA-COV003, CA-SIG003, CA-EXC001 in POLICY…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Frameworks/Conditional-Access-Baseline/Policies/CA-COV003-WorkloadIdentities-TrustedLocations.json — blocks service principal sign-ins from outside a tenant-defined Trusted IPs named location. Requires Microsoft Entra Workload Identities Premium SKU; CAE does not apply to workload identity tokens.
 - Frameworks/Conditional-Access-Baseline/Policies/CA-COV003-WorkloadIdentities.md — design doc covering hard prerequisites (Workload Identities Premium, Trusted IPs named location), per-SPN exclusion model (distinct from user-targeted CA-EXC001), SPN discovery query, and CAE limitations for workload identities.
 
+### Changed
+
+- Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md — documented section 6.7 (`CA-COV003-WorkloadIdentities-TrustedLocations`) and section 6.8 (`CA-SIG003-Guests-RequireMFA`) per-policy specs; added rollout-sequence rows 7 and 8; added `CA-EXC001` reference under section 4.1; updated section 6 intro count from "six" to "eight" starter policies.
+
 ### Fixed
 
 - Get-CABaselineImpact.ps1 — StrictMode-safe check for `@odata.nextLink` so the script doesn't error on the final page of sign-in results.

--- a/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
@@ -2,7 +2,7 @@
 
 This document specifies the design philosophy, naming convention, persona model, and exclusion strategy for the Conditional Access Baseline framework. It is the prerequisite reading for anyone deploying, extending, or auditing the baseline.
 
-The per-policy design specifications (one subsection for each of the six starter policies) are appended in the following section of this document.
+The per-policy design specifications (one subsection for each starter policy) are appended in the following section of this document.
 
 ---
 
@@ -16,19 +16,19 @@ Four principles anchor every design decision in this framework:
 
 **What it means:** No orphaned identities, applications, or legacy protocols should be able to authenticate outside the scope of Conditional Access. Every user, every guest, every workload identity, and every cloud app must be covered by at least one evaluated policy.
 
-**How this baseline implements it:** Policies `CA-COV001` (Block legacy authentication) and `CA-COV002` (Require MFA for all users) are scoped to "All users" and "All cloud apps" — with controlled exclusions for emergency access accounts and workload identities that have their own hardened paths.
+**How this baseline implements it:** Policies `CA-COV001` (Block legacy authentication) and `CA-COV002` (Require MFA for all users) are scoped to "All users" and "All cloud apps" — with controlled exclusions for emergency access accounts and workload identities that have their own hardened paths. `CA-COV003` (Workload Identities — Trusted Locations) closes the workload-identity coverage gap by restricting service-principal sign-ins to a defined egress.
 
 ### 1.2 No standing exclusions
 
 **What it means:** Exclusions are a common attack path. An exclusion group that persists indefinitely becomes a backdoor — one compromised member, and the entire baseline can be bypassed. Exclusions must be time-bound, auditable, and reviewed.
 
-**How this baseline implements it:** Only two exclusion groups are considered permanent: emergency access accounts (two total, monitored by alert) and workload identities governed by a separate workload-identity policy set. All other exclusions are temporary, tracked by owner and expiration date, and reviewed quarterly.
+**How this baseline implements it:** Only two exclusion groups are considered permanent: emergency access accounts (two total, monitored by alert) and workload identities governed by a separate workload-identity policy set. All other exclusions are temporary, tracked by owner and expiration date, and reviewed quarterly. The operational specification for the emergency access exclusion is `CA-EXC001-EmergencyAccess-Exclusion.md`.
 
 ### 1.3 Layered signals
 
 **What it means:** Strong security emerges from combining signals — identity risk, device state, location, application sensitivity — not from any single control. A policy that evaluates only one signal is a single point of failure.
 
-**How this baseline implements it:** Policies in the `CA-SIG` series evaluate multiple signals in combination. `CA-SIG001` layers application sensitivity with device compliance; `CA-SIG002` layers sign-in risk with step-up authentication. This is the difference between "require MFA" and "require MFA *because we detected risk*."
+**How this baseline implements it:** Policies in the `CA-SIG` series evaluate multiple signals in combination. `CA-SIG001` layers application sensitivity with device compliance; `CA-SIG002` layers sign-in risk with step-up authentication; `CA-SIG003` layers user-type (guest) with the MFA control. This is the difference between "require MFA" and "require MFA *because we detected risk*."
 
 ### 1.4 Authentication Strengths
 
@@ -51,7 +51,7 @@ CA-[PrinciplePrefix][Number]-[Persona]-[Action]
 | Prefix | Principle | Use when the policy primarily enforces... |
 |--------|-----------|-------------------------------------------|
 | `COV` | Identity-wide coverage | Blanket coverage of users, apps, or protocols |
-| `EXC` | No standing exclusions | Time-bound access paths, JIT elevation, guest lifecycle |
+| `EXC` | No standing exclusions | Time-bound access paths, JIT elevation, guest lifecycle, documented permanent exclusions |
 | `SIG` | Layered signals | Device, location, or risk signals shaping access decisions |
 | `AUT` | Authentication Strengths | Phishing-resistant MFA requirements |
 
@@ -89,8 +89,8 @@ Exclusions are the single most dangerous element of any Conditional Access basel
 
 ### 4.1 Permanent exclusions (2 total)
 
-1. **Emergency access accounts** (`CA-Persona-EmergencyAccess`) — excluded from every policy. Two accounts, cloud-only, stored offline in a sealed envelope, monitored by a sign-in alert rule that pages the security team on any use.
-2. **Workload identities** — excluded from user-scoped policies and governed by a separate workload-identity policy set.
+1. **Emergency access accounts** (`CA-Persona-EmergencyAccess`) — excluded from every policy. Two accounts, cloud-only, stored offline in a sealed envelope, monitored by a sign-in alert rule that pages the security team on any use. Operational specification (key custody, alert rule, recovery test cadence): `CA-EXC001-EmergencyAccess-Exclusion.md`.
+2. **Workload identities** — excluded from user-scoped policies and governed by a separate workload-identity policy set (see `CA-COV003`).
 
 ### 4.2 Temporary exclusions
 
@@ -124,6 +124,10 @@ Policies should be staged, enforced, and promoted in the following order. Each s
 | 4 | `CA-AUT002-PrivRoles-RequirePhishResistantMFA` | 7 days | PIM-path parallel to CA-AUT001 |
 | 5 | `CA-SIG001-SensApps-RequireCompliantDevice` | 14 days | Requires device compliance maturity — soak longer |
 | 6 | `CA-SIG002-AllUsers-RequireStepUpOnRisk` | 14 days | Requires Entra ID P2 + Identity Protection tuning — soak longer |
+| 7 | `CA-COV003-WorkloadIdentities-TrustedLocations` | 14 days | Workload-identity coverage; soak to inventory legitimate egress IPs before enforcement |
+| 8 | `CA-SIG003-Guests-RequireMFA` | 7 days | Guest scope is bounded; soak captures cross-tenant B2B sign-in patterns |
+
+`CA-EXC001-EmergencyAccess-Exclusion` is a documented permanent exclusion, not a deployable policy, and is not part of the rollout sequence.
 
 **Do not skip report-only.** Every policy must be validated in report-only mode before enforcement, no matter how confident the reviewer is in its scope.
 
@@ -131,7 +135,7 @@ Policies should be staged, enforced, and promoted in the following order. Each s
 
 ## 6. Per-policy design specifications
 
-Each of the six starter policies is specified below. Every spec follows the same structure: intent, principle mapping, scope, conditions, controls, license requirements, validation steps, and the JSON template path.
+Each of the eight starter policies is specified below. Every spec follows the same structure: intent, principle mapping, scope, conditions, controls, license requirements, validation steps, and the JSON template path. The standing exclusion specification for emergency access accounts (`CA-EXC001`) is documented separately in `CA-EXC001-EmergencyAccess-Exclusion.md`.
 
 ---
 
@@ -141,26 +145,30 @@ Each of the six starter policies is specified below. Every spec follows the same
 
 **Principle mapping:** Primary — COV (Identity-wide coverage). This policy establishes the coverage floor by eliminating the authentication paths that would bypass every other policy.
 
-**Scope**
+#### Scope
+
 - Included users: All users
 - Excluded users: `CA-Persona-EmergencyAccess`
 - Included cloud apps: All cloud apps
 - Excluded cloud apps: None
 
-**Conditions**
+#### Conditions
+
 - Client apps: Exchange ActiveSync clients, Other clients
 - Device platforms: Any
 - Locations: Any
 - Sign-in risk: Not evaluated
 - User risk: Not evaluated
 
-**Controls**
+#### Controls
+
 - Grant: Block access
 - Session: None
 
 **License requirements:** Entra ID P1 (minimum)
 
-**Validation in report-only**
+#### Validation in report-only
+
 - Review sign-in logs filtered by Client app = Exchange ActiveSync and Client app = Other clients to confirm whether these paths are active in your tenant
 - Identify any service accounts or legacy applications still using basic auth; migrate to modern auth or scope them under a workload-identity policy BEFORE promoting to enforced
 - Confirm zero unexplained sign-in failures during the soak period
@@ -175,26 +183,30 @@ Each of the six starter policies is specified below. Every spec follows the same
 
 **Principle mapping:** Primary — COV (Identity-wide coverage). Layered beneath CA-COV001 to ensure any authentication that clears the legacy-auth block is still MFA-protected.
 
-**Scope**
+#### Scope
+
 - Included users: All users
 - Excluded users: `CA-Persona-EmergencyAccess`, `CA-Persona-WorkloadIdentities`
 - Included cloud apps: All cloud apps
 - Excluded cloud apps: None
 
-**Conditions**
+#### Conditions
+
 - Client apps: Browser, Mobile apps and desktop clients
 - Device platforms: Any
 - Locations: Any
 - Sign-in risk: Not evaluated
 - User risk: Not evaluated
 
-**Controls**
+#### Controls
+
 - Grant: Require multifactor authentication
 - Session: None
 
 **License requirements:** Entra ID P1 (minimum)
 
-**Validation in report-only**
+#### Validation in report-only
+
 - Run the "Users registered for MFA" report; ensure every user has at least one MFA method registered before enforcement
 - Soak for 14 days to capture low-frequency sign-ins (monthly reports, quarterly tools, dormant accounts)
 - Confirm the `CA-Persona-EmergencyAccess` exclusion is intact — if the policy accidentally applies to break-glass accounts, the tenant can be locked out
@@ -209,26 +221,30 @@ Each of the six starter policies is specified below. Every spec follows the same
 
 **Principle mapping:** Primary — AUT (Authentication Strengths). Secondary — SIG, because the control is gated on identity-role signal.
 
-**Scope**
+#### Scope
+
 - Included users: `CA-Persona-GlobalAdmins`
 - Excluded users: `CA-Persona-EmergencyAccess`
 - Included cloud apps: All cloud apps
 - Excluded cloud apps: None
 
-**Conditions**
+#### Conditions
+
 - Client apps: All
 - Device platforms: Any
 - Locations: Any
 - Sign-in risk: Not evaluated
 - User risk: Not evaluated
 
-**Controls**
+#### Controls
+
 - Grant: Require authentication strength — Phishing-resistant MFA
 - Session: None
 
 **License requirements:** Entra ID P1 (Authentication Strengths is a P1 feature)
 
-**Validation in report-only**
+#### Validation in report-only
+
 - Confirm every member of `CA-Persona-GlobalAdmins` has a registered phishing-resistant credential (FIDO2 key, Windows Hello, or certificate) BEFORE enforcement — lockout risk is highest here
 - Provision backup FIDO2 keys for each admin; keep one secured offline
 - Verify break-glass accounts are NOT members of `CA-Persona-GlobalAdmins`
@@ -243,27 +259,31 @@ Each of the six starter policies is specified below. Every spec follows the same
 
 **Principle mapping:** Primary — AUT (Authentication Strengths). Secondary — SIG, because the control responds dynamically to the user's effective role at sign-in.
 
-**Scope**
+#### Scope
+
 - Included users: All users
 - Excluded users: `CA-Persona-EmergencyAccess`
 - Included cloud apps: All cloud apps
 - Excluded cloud apps: None
 - Directory role condition (minimum): Global Administrator, Privileged Role Administrator, Security Administrator, User Administrator, Conditional Access Administrator, Exchange Administrator, SharePoint Administrator, Helpdesk Administrator, Billing Administrator, Application Administrator, Cloud Application Administrator, Authentication Administrator. Expand based on your privileged role inventory.
 
-**Conditions**
+#### Conditions
+
 - Client apps: All
 - Device platforms: Any
 - Locations: Any
 - Sign-in risk: Not evaluated
 - User risk: Not evaluated
 
-**Controls**
+#### Controls
+
 - Grant: Require authentication strength — Phishing-resistant MFA
 - Session: None
 
 **License requirements:** Entra ID P2 (required for PIM); P1 minimum for Authentication Strengths
 
-**Validation in report-only**
+#### Validation in report-only
+
 - Inventory all directory roles in use via `Get-MgDirectoryRole` in Microsoft Graph PowerShell; confirm the condition list covers every privileged role you assign
 - Validate that any user who might activate a role has a phishing-resistant credential registered
 - Test the full PIM activation flow with a pilot user before enforcement
@@ -278,26 +298,30 @@ Each of the six starter policies is specified below. Every spec follows the same
 
 **Principle mapping:** Primary — SIG (Layered signals). Combines application-sensitivity signal with device-state signal to make access conditional on both identity assurance AND endpoint integrity.
 
-**Scope**
+#### Scope
+
 - Included users: `CA-Persona-InternalUsers`
 - Excluded users: `CA-Persona-EmergencyAccess`, `CA-Persona-WorkloadIdentities`
 - Included cloud apps: Sensitive Apps set — typically includes Microsoft Admin portals, Azure Management, Microsoft Intune, Microsoft 365 admin center, Exchange Online Admin, SharePoint Admin, and any in-house finance/HR/crown-jewel SaaS
 - Excluded cloud apps: None
 
-**Conditions**
+#### Conditions
+
 - Client apps: Browser, Mobile apps and desktop clients
 - Device platforms: Any
 - Locations: Any
 - Sign-in risk: Not evaluated
 - User risk: Not evaluated
 
-**Controls**
+#### Controls
+
 - Grant: Require device to be marked as compliant OR Require Hybrid Azure AD joined device (use OR to support mixed modern and legacy compliance postures)
 - Session: None
 
 **License requirements:** Entra ID P1 + Microsoft Intune (or Hybrid join via Active Directory)
 
-**Validation in report-only**
+#### Validation in report-only
+
 - Confirm every user in `CA-Persona-InternalUsers` has at least one device registered and marked compliant in Intune (or Hybrid-joined) BEFORE enforcement
 - Run the Intune compliance dashboard; remediate non-compliant devices in the pilot group before tenant-wide rollout
 - Validate the sensitive-app scope matches your organization's crown-jewel app list — do not over-scope in the first release
@@ -312,29 +336,109 @@ Each of the six starter policies is specified below. Every spec follows the same
 
 **Principle mapping:** Primary — SIG (Layered signals). Consumes Identity Protection sign-in risk and responds dynamically.
 
-**Scope**
+#### Scope
+
 - Included users: All users
 - Excluded users: `CA-Persona-EmergencyAccess`, `CA-Persona-WorkloadIdentities`
 - Included cloud apps: All cloud apps
 - Excluded cloud apps: None
 
-**Conditions**
+#### Conditions
+
 - Client apps: All
 - Device platforms: Any
 - Locations: Any
 - Sign-in risk: Medium, High
 - User risk: Not evaluated here (handled separately in a future CA-SIG policy addressing user-risk remediation)
 
-**Controls**
+#### Controls
+
 - Grant: Require authentication strength — Multifactor authentication (consider Phishing-resistant MFA for high-risk sign-ins based on your tenant's false-positive tolerance)
 - Session: Sign-in frequency — every time (forces re-auth on risky sessions)
 
 **License requirements:** Entra ID P2 (Identity Protection is a P2 feature)
 
-**Validation in report-only**
+#### Validation in report-only
+
 - Review Identity Protection risk detections for the prior 30 days to understand false-positive volume in your tenant
 - Tune exclusions for known service-account sign-in patterns that legitimately trigger risk detections
 - Soak for 14 days minimum; risk detections surface unevenly, and a shorter soak can miss edge cases
 - Confirm self-service password reset and MFA registration are both deployed — risky sign-ins must have a remediation path
 
 **JSON template:** `../Policies/CA-SIG002-AllUsers-RequireStepUpOnRisk.json` (planned)
+
+---
+
+### 6.7 `CA-COV003-WorkloadIdentities-TrustedLocations`
+
+**Intent:** Restrict service-principal (workload identity) sign-ins to a defined set of Named Locations representing the organization's approved egress IP ranges. Closes the workload-identity coverage gap left by the user-scoped CA-COV policies, which exclude `CA-Persona-WorkloadIdentities` so that machine sign-ins are not blocked by interactive-user controls.
+
+**Principle mapping:** Primary — COV (Identity-wide coverage). This policy is the workload-side equivalent of CA-COV001/CA-COV002 — it ensures the workload-identity exclusion in the user-scoped policies does not become a coverage hole.
+
+#### Scope
+
+- Included workload identities: `CA-Persona-WorkloadIdentities` (or "All service principals" in tenants with a complete workload-identity inventory)
+- Excluded workload identities: None
+- Included cloud apps: All cloud apps
+- Excluded cloud apps: None
+
+#### Conditions
+
+- Locations: Include All locations; Exclude Trusted Network Locations (one or more Named Locations representing approved egress)
+- Client apps: Not applicable (workload identity policies do not evaluate client app)
+- Device platforms: Not applicable
+- Sign-in risk: Not evaluated (handled separately by Workload Identity Risk if licensed)
+- User risk: Not applicable
+
+#### Controls
+
+- Grant: Block access
+- Session: None
+
+**License requirements:** Microsoft Entra Workload Identities Premium add-on (required to scope Conditional Access to service principals)
+
+#### Validation in report-only
+
+- Enumerate active service-principal sign-ins for the prior 30 days via `Get-MgAuditLogSignIn` filtered by `signInEventTypes/any(t:t eq 'servicePrincipal')`; record the source IPs
+- Confirm every legitimate workload signs in from a known trusted IP range before enforcement; coordinate with platform engineering to register all egress IPs as a Named Location
+- Identify any third-party SaaS-to-tenant integrations that authenticate from vendor-owned IP ranges; either add those ranges to the trusted set or scope the service principal under a tighter, vendor-specific policy
+- Soak for 14 days minimum to capture low-frequency batch jobs and quarterly automation
+
+**JSON template:** `../Policies/CA-COV003-WorkloadIdentities-TrustedLocations.json`
+
+---
+
+### 6.8 `CA-SIG003-Guests-RequireMFA`
+
+**Intent:** Require MFA for every interactive guest (B2B) sign-in into the tenant. Closes the gap where home-tenant authentication assurance for guest users may be weaker than the resource tenant's standard for internal users.
+
+**Principle mapping:** Primary — SIG (Layered signals). Combines user-type signal (`userType eq 'Guest'`) with the MFA control. Secondary — COV, because it extends the MFA floor established by CA-COV002 to the guest population that is otherwise governed by cross-tenant access settings.
+
+#### Scope
+
+- Included users: `CA-Persona-GuestUsers`
+- Excluded users: `CA-Persona-EmergencyAccess`
+- Included cloud apps: All cloud apps
+- Excluded cloud apps: None
+
+#### Conditions
+
+- Client apps: Browser, Mobile apps and desktop clients
+- Device platforms: Any
+- Locations: Any
+- Sign-in risk: Not evaluated
+- User risk: Not evaluated
+
+#### Controls
+
+- Grant: Require multifactor authentication
+- Session: None
+
+**License requirements:** Entra ID P1 (minimum)
+
+#### Validation in report-only
+
+- Inventory all active guest accounts via `Get-MgUser -Filter "userType eq 'Guest'"`; confirm the dynamic membership of `CA-Persona-GuestUsers` matches that inventory
+- Configure Cross-Tenant Access Settings to trust home-tenant MFA claims where appropriate; otherwise guests will be challenged on every resource-tenant sign-in
+- Soak for 7 days to capture monthly cross-tenant guest sign-ins and any low-frequency external collaborators
+- Verify break-glass accounts are NOT members of `CA-Persona-GuestUsers`


### PR DESCRIPTION
## What

Brings POLICY-DESIGN.md in line with the v1.1 policy artifacts already merged under `[Unreleased]`:

- Section 4.1: pointer to `CA-EXC001-EmergencyAccess-Exclusion.md` (operational spec for the emergency access standing exclusion) and to `CA-COV003` (for the workload-identity exclusion path)
- Section 5: rollout rows 7 (`CA-COV003`) and 8 (`CA-SIG003`); note that `CA-EXC001` is a documented exclusion, not a deployable policy
- Section 6 intro: "six starter policies" -> "eight starter policies"
- Section 6.7: full per-policy spec for `CA-COV003-WorkloadIdentities-TrustedLocations`
- Section 6.8: full per-policy spec for `CA-SIG003-Guests-RequireMFA`
- Principle-section examples (1.1, 1.2, 1.3) reference the new policies
- EXC prefix description (2.1) extended to cover documented permanent exclusions

## Why

POLICY-DESIGN.md is the prerequisite reading for the framework. The new policies were merged into `[Unreleased]` without a matching design spec, which makes them undefendable in a future audit and harder to extend. Closing that gap before tagging v1.1.0.

Design principle citation: COV (sections 1.1, 1.2) and SIG (section 1.3) — both new specs map to existing principles already documented in this file.

## How validated

- New 6.7/6.8 sections follow the existing 6.x template (intent -> principle mapping -> scope -> conditions -> controls -> license -> validation -> JSON template path)
- No tenant-specific IDs introduced
- No JSON template changes — all referenced policy templates already exist under `Frameworks/Conditional-Access-Baseline/Policies/`
- Markdownlint clean against `.markdownlint.json`

## PR checklist

- [x] One logical change (per CONTRIBUTING.md): documenting v1.1 personas in POLICY-DESIGN.md
- [x] Cites design principle from POLICY-DESIGN.md (COV, SIG)
- [x] CHANGELOG entry under `## [Unreleased]` -> `### Changed`
- [x] No tenant IDs committed
- [x] `Deploy-CABaseline.ps1 -WhatIf` still parses every template (no JSON changes)
- [x] Markdownlint clean