### PR TITLE
fix(ca-baseline): allow empty-string messages in Write-Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Deploy-CABaseline.ps1 — hardened `Write-Status` against empty-string messages by adding `[AllowEmptyString()]` to the `$Message` parameter. Prevents the StrictMode regression that surfaced in v1.0.1 where `Write-Status ""` (used for blank-line spacing) threw a parameter validation error.
 - Get-CABaselineImpact.ps1 — StrictMode-safe check for `@odata.nextLink` so the script doesn't error on the final page of sign-in results.
 - Get-CABaselineImpact.ps1 — force array semantics around `.Count` accesses so the script works when 0 or 1 sign-ins / records / unique users exist (StrictMode correctness).
 

--- a/Frameworks/Conditional-Access-Baseline/Scripts/Deploy-CABaseline.ps1
+++ b/Frameworks/Conditional-Access-Baseline/Scripts/Deploy-CABaseline.ps1
@@ -93,7 +93,7 @@ $ErrorActionPreference = 'Stop'
 
 function Write-Status {
     param(
-        [Parameter(Mandatory)][string]$Message,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Message,
         [ValidateSet('Info', 'Success', 'Warning', 'Error')][string]$Level = 'Info'
     )
     $color = switch ($Level) {


### PR DESCRIPTION
## What

Adds `[AllowEmptyString()]` to the `$Message` parameter on `Write-Status` in `Deploy-CABaseline.ps1` so that `Write-Status ""` (used for visual blank-line spacing) no longer trips PowerShell's mandatory-parameter validation under StrictMode.

## Why

This is the regression-prevention item carried over from v1.0.1. In v1.0.1 we patched `Deploy-CABaseline.ps1` by replacing a `Write-Status ""` call with `Write-Host ""` to unblock the deployer, but the underlying parameter contract was never hardened. `Get-CABaselineImpact.ps1` (added during v1.1) followed the same blank-line-spacing pattern and would hit the same failure mode the moment anyone called `Write-Status ""` from it. This PR fixes the function itself so the pattern is safe everywhere.

## Design principle

Operational maturity for the Conditional Access Baseline tooling — supports all four principles indirectly by keeping the deployment and telemetry scripts reliable. No policy semantics change.

## How validated

- `Deploy-CABaseline.ps1 -WhatIf` parses cleanly and runs end-to-end against all eight policy templates.
- `Write-Status ""` no longer throws under `Set-StrictMode -Version Latest`.
- Existing non-empty calls to `Write-Status` continue to render with the correct level prefix and color.

## PR checklist

- [x] Branched from `main`
- [x] CHANGELOG entry added under `[Unreleased]` → `### Fixed`
- [x] Markdownlint clean
- [x] No policy JSON or placeholder changes
- [x] `Deploy-CABaseline.ps1 -WhatIf` parses every template