### PR TITLE
release: v1.1.0 — operational maturity & persona completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-05-01
+
+Operational maturity and persona completeness release for the **Conditional Access Baseline**. Adds the External Guests and Workload Identities personas, a written Emergency Access exclusion contract, a report-only telemetry script, repo governance scaffolding, and a hardened deployer.
+
 ### Added
 
 - Scripts/Get-CABaselineImpact.ps1 — report-only telemetry tool: analyzes sign-in logs and summarizes what each report-only CA policy would have done if enforced.
@@ -29,15 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deploy-CABaseline.ps1 — hardened `Write-Status` against empty-string messages by adding `[AllowEmptyString()]` to the `$Message` parameter. Prevents the StrictMode regression that surfaced in v1.0.1 where `Write-Status ""` (used for blank-line spacing) threw a parameter validation error.
 - Get-CABaselineImpact.ps1 — StrictMode-safe check for `@odata.nextLink` so the script doesn't error on the final page of sign-in results.
 - Get-CABaselineImpact.ps1 — force array semantics around `.Count` accesses so the script works when 0 or 1 sign-ins / records / unique users exist (StrictMode correctness).
-
-### Planned for v1.1 of the **Conditional Access Baseline**
-
-- Repo hygiene: issue templates, PR template, `CODEOWNERS`, GitHub Project board
-- Report-only telemetry script to quantify impact before enforcement
-- Workload Identities persona and baseline policy
-- External Guests (B2B) persona and baseline policy
-- Explicit documented Emergency Access exclusion policy template
-- `Write-Status` function hardened with `[AllowEmptyString()]` to prevent future regressions
 
 ---
 
@@ -101,6 +96,10 @@ First public release of the **Conditional Access Baseline** framework.
 This framework was shaped by the public work of Joey Verlinden, Daniel Chronlund, and Claus Jespersen on Conditional Access design patterns.
 
 ---
+[Unreleased] : <https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/compare/v1.1.0...HEAD>
 
-[Unreleased]: https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/releases/tag/v1.0.0
+[1.1.0] : <https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/compare/v1.0.1...v1.1.0>
+
+[1.0.1] : <https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/compare/v1.0.0...v1.0.1>
+
+[1.0.0] : <https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/releases/tag/v1.0.0>

--- a/Frameworks/Conditional-Access-Baseline/README.md
+++ b/Frameworks/Conditional-Access-Baseline/README.md
@@ -2,7 +2,7 @@
 
 A defensible Conditional Access baseline for Microsoft Entra ID — eight starter policies that enforce Zero Trust access principles, grounded in the risk-reduction framing published in [Why Entra ID Conditional Access Fails in Practice (And How to Fix It)](https://www.cloudharborconsulting.cloud/post/why-entra-id-conditional-access-fails-in-practice-and-how-to-fix-it).
 
-**Status:** 🟢 Released — v1.0.0
+**Status:** 🟢 Released — v1.1.0
 
 ## Why a baseline first
 

--- a/Frameworks/Conditional-Access-Baseline/README.md
+++ b/Frameworks/Conditional-Access-Baseline/README.md
@@ -103,14 +103,15 @@ This baseline is deployed around the people it protects, not around individual t
 - [x] Tag v1.0.0 release
 - [x] v1.0.1 patch — deployer hardening and doc fixes
 
-### v1.1 — Operational maturity & persona completeness (in progress)
+### v1.1 — Operational maturity & persona completeness (shipped)
 
 - [x] Repo governance: issue templates, PR template, CODEOWNERS, branch protection, project board
 - [x] `Get-CABaselineImpact.ps1` — report-only telemetry summarizer (WouldBlock / WouldChallenge / WouldPass / NotApplied)
 - [x] `CA-EXC001-EmergencyAccess-Exclusion.md` — written exclusion contract with monthly attestation and quarterly recovery drill
 - [x] `CA-SIG003-Guests-RequireMFA.json` — MFA for all external user types, honors CA-EXC001
 - [x] `CA-COV003-WorkloadIdentities` — service principal targeting with IP filters
-- [ ] Persona / ROI doc rollup + tag v1.1.0
+- [x] Persona / ROI doc rollup + tag v1.1.0
+- [x] `Deploy-CABaseline.ps1` — `Write-Status` hardened with `[AllowEmptyString()]` to prevent StrictMode regression
 
 ### v1.2 — Candidates (not committed)
 


### PR DESCRIPTION
## What

Cuts the v1.1.0 release of the Conditional Access Baseline.

- Promotes `CHANGELOG.md` `[Unreleased]` → `[1.1.0]` dated 2026-05-01.
- Resets `[Unreleased]` to empty.
- Removes the "Planned for v1.1" subsection (those items are now the release contents).
- Fixes the broken compare-link footer that previously skipped v1.0.1 (`v1.0.0...HEAD`); footer now chains `Unreleased → 1.1.0 → 1.0.1 → 1.0.0`.
- Updates the framework README status banner from v1.0.0 to v1.1.0.
- Flips the v1.1 roadmap heading from "(in progress)" to "(shipped)" and checks the rollup box.

## Why

v1.1 closes out the operational maturity and persona completeness milestone:

- External Guests persona via `CA-SIG003-Guests-RequireMFA`
- Workload Identities persona via `CA-COV003-WorkloadIdentities-TrustedLocations`
- Written Emergency Access exclusion contract via `CA-EXC001`
- Report-only telemetry via `Get-CABaselineImpact.ps1`
- Repo governance scaffolding (issue templates, PR template, CODEOWNERS)
- Deployer hardening (`Write-Status` `[AllowEmptyString()]`)
- Design doc and ROI doc updated to cover all eight policies and four personas

Tagging now lets downstream consumers pin to a stable v1.1.0 instead of tracking `main`.

## Design principle

Release hygiene — no policy semantics change. Carries forward all four defensible-baseline principles (COV, EXC, SIG, AUT) by keeping the published surface and the changelog in sync.

## How validated

- `CHANGELOG.md` parses against Keep a Changelog 1.1.0 — every section header has the expected level, every release has a date, footer compare links resolve.
- Framework README renders cleanly; status banner and roadmap section reflect shipped state.
- Markdownlint clean.
- No code changes — `Deploy-CABaseline.ps1 -WhatIf` continues to parse all eight policy templates as of the last merged state.

## PR checklist

- [x] Branched from `main`
- [x] CHANGELOG `[Unreleased]` promoted to `[1.1.0]` with date
- [x] CHANGELOG `[Unreleased]` reset to empty
- [x] Compare-link footer chain corrected
- [x] Framework README status banner and roadmap updated
- [x] Markdownlint clean
- [x] No policy JSON changes