### PR TITLE
docs: sync root README status to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Top-level `README.md` — Frameworks table status for the Conditional Access Baseline updated from `v1.0.0` to `v1.1.0` to match the v1.1.0 release. Documentation-only correction; missed during the v1.1.0 release prep.
+
 ## [1.1.0] — 2026-05-01
 
 Operational maturity and persona completeness release for the **Conditional Access Baseline**. Adds the External Guests and Workload Identities personas, a written Emergency Access exclusion contract, a report-only telemetry script, repo governance scaffolding, and a hardened deployer.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Every framework in this repo includes:
 
 | Framework | Focus Area | Status |
 |-----------|------------|--------|
-| [Conditional Access Baseline](./Frameworks/Conditional-Access-Baseline/) | Entra ID, Zero Trust | 🟢 Released -- v1.0.0 |
+| [Conditional Access Baseline](./Frameworks/Conditional-Access-Baseline/) | Entra ID, Zero Trust | 🟢 Released -- v1.1.0 |
 | [Intune Compliance Baseline](./Frameworks/Intune-Compliance-Baseline/) | Endpoint Management | ⚪ Planned (Q3 2026) |
 | [Entra ID Governance Toolkit](./Frameworks/Entra-ID-Governance-Toolkit/) | Identity Governance | ⚪ Planned (Q4 2026) |
 | [Defender XDR Detection Rules](./Frameworks/Defender-XDR-Detection-Rules/) | SIEM & XDR | ⚪ Planned (Q1 2027) |


### PR DESCRIPTION
## What

Updates the root `README.md` Frameworks table so the Conditional Access Baseline status reads `🟢 Released -- v1.1.0` instead of `🟢 Released -- v1.0.0`. Adds a matching CHANGELOG entry under `[Unreleased]` → `### Fixed`.

## Why

v1.1.0 shipped today (2026-05-01), and the framework-level README and tag were updated as part of the release PR, but the root README's Frameworks table was missed. This corrects the inconsistency so anyone landing on the repo root sees the current released version.

## Design principle

Release hygiene — documentation-only correction. No policy semantics, no script behavior, no template changes.

## How validated

- Diff is two lines: one in `README.md`, one CHANGELOG bullet.
- Markdownlint clean.
- All other framework status entries already reflect their roadmap state correctly.

## PR checklist

- [x] Branched from `main`
- [x] CHANGELOG entry added under `[Unreleased]` → `### Fixed`
- [x] Markdownlint clean
- [x] No policy JSON or script changes