### PR TITLE
feat: add custom authentication-strength templates (StandardAuth, Str…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Frameworks/Conditional-Access-Baseline/Policies/CA-EXC002-ServiceAccounts-Exclusion.md — written contract documenting that every human-targeted CA-* policy excludes the ServiceAccounts persona via `users.excludeGroups`, and that the persona is the inclusion target for the v1.2 compensating control (CA-COV010-ServiceAccounts-BlockUntrustedLocations). Defines persona membership rules, monthly attestation, quarterly sign-in review, and credential rotation procedure. Parallel in structure to CA-EXC001-EmergencyAccess-Exclusion.md.
+- Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/ — new folder for tenant-scoped artifacts that CA policy templates depend on (custom authentication strengths, named locations). Includes a README documenting the schema and how `Deploy-CABaseline.ps1` will resolve placeholder IDs against the tenant.
+- Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-StandardAuth.json — custom authentication strength: Windows Hello for Business, FIDO2, or password + Microsoft Authenticator push. Default strength for general user populations during the rollout to phishing-resistant credentials.
+- Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-StrongAuth.json — custom authentication strength: Windows Hello for Business or FIDO2. Phishing-resistant only.
+- Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-AdminAuth.json — custom authentication strength: FIDO2 only. Narrowest strength in the baseline; for privileged accounts and admin roles.
 
 ### Fixed
 
-- Top-level `README.md` — Frameworks table status for the Conditional Access Baseline updated from `v1.0.0` to `v1.1.0` to match the v1.1.0 release. Documentation-only correction; missed during the v1.1.0 release prep.
-
-## [1.1.0] — 2026-05-01
+- Top-level `README.md` — Frameworks table status for the Conditional Access Baseline updated from `v1.0.0` to `v1.1.0` to match the v1.1.0 release. Documentation-only correction; missed during the v1.1.0 release prep.## [1.1.0] — 2026-05-01
 
 Operational maturity and persona completeness release for the **Conditional Access Baseline**. Adds the External Guests and Workload Identities personas, a written Emergency Access exclusion contract, a report-only telemetry script, repo governance scaffolding, and a hardened deployer.
 

--- a/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-AdminAuth.json
+++ b/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-AdminAuth.json
@@ -1,0 +1,9 @@
+{
+  "displayName": "AdminAuth",
+  "description": "FIDO2 hardware key only. The narrowest custom auth strength in the baseline. Use for privileged accounts and admin roles. No Windows Hello, no password-backed factors.",
+  "policyType": "custom",
+  "requirementsSatisfied": "mfa",
+  "allowedCombinations": [
+    "fido2"
+  ]
+}

--- a/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-StandardAuth.json
+++ b/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-StandardAuth.json
@@ -1,0 +1,11 @@
+{
+  "displayName": "StandardAuth",
+  "description": "Phishing-resistant first, with a password + Microsoft Authenticator push fallback. Default strength for general user populations during the rollout to phishing-resistant credentials.",
+  "policyType": "custom",
+  "requirementsSatisfied": "mfa",
+  "allowedCombinations": [
+    "windowsHelloForBusiness",
+    "fido2",
+    "password,microsoftAuthenticatorPush"
+  ]
+}

--- a/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-StrongAuth.json
+++ b/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-StrongAuth.json
@@ -1,0 +1,10 @@
+{
+  "displayName": "StrongAuth",
+  "description": "Phishing-resistant only. Windows Hello for Business or FIDO2 hardware key. Use for sensitive scenarios where the rollout to phishing-resistant credentials is complete and password-backed MFA is no longer acceptable.",
+  "policyType": "custom",
+  "requirementsSatisfied": "mfa",
+  "allowedCombinations": [
+    "windowsHelloForBusiness",
+    "fido2"
+  ]
+}

--- a/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/README.md
+++ b/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/README.md
@@ -1,0 +1,36 @@
+# Conditional Access Baseline — Supporting Artifacts
+
+Tenant-scoped artifacts that CA policy templates depend on. These are not Conditional Access policies; they are prerequisites that must exist (or be created) in the tenant before the policies that reference them can be deployed.
+
+Each artifact is shipped as a Graph-API-shaped JSON template, parallel to the CA policy templates in `../Policies/`.
+
+## Authentication strengths (v1.2)
+
+Three custom authentication strengths that the v1.2 policy slate binds via `grantControls.authenticationStrength`:
+
+| Artifact | Allowed combinations | Purpose |
+|----------|----------------------|---------|
+| CA-AUTH-STRENGTH-StandardAuth.json | Windows Hello for Business, FIDO2, password + Microsoft Authenticator push | Default strength for general user populations. Phishing-resistant first, with a password-backed fallback for rollout periods. |
+| CA-AUTH-STRENGTH-StrongAuth.json | Windows Hello for Business, FIDO2 | Phishing-resistant only. No password-backed factors. Use for sensitive scenarios where the rollout to phishing-resistant credentials is complete. |
+| CA-AUTH-STRENGTH-AdminAuth.json | FIDO2 only | The narrowest strength in the baseline. Use for privileged accounts and admin roles. No Windows Hello, no password-backed factors. |
+
+`Deploy-CABaseline.ps1` (extended in a later v1.2 PR) will resolve each `REPLACE_WITH_AUTH_STRENGTH_*_ID` placeholder in the policy templates against the tenant's `/policies/authenticationStrengthPolicies` collection, matching by `displayName`. If a custom strength does not exist, the deployer creates it from the template before policy deployment.
+
+## Schema
+
+Authentication-strength templates follow the Microsoft Graph schema for `authenticationStrengthPolicy`:
+
+- `displayName` — exact name the deployer matches against
+- `description` — repo-side commentary explaining when to use the strength
+- `policyType` — always `custom` for templates in this folder
+- `allowedCombinations` — list of allowed authentication method combinations
+- `requirementsSatisfied` — always `mfa`
+
+Server-side fields (`id`, `createdDateTime`, `modifiedDateTime`, `combinationConfigurations`) are omitted from templates.
+
+## Adding a new artifact
+
+1. Add the JSON template to this folder using the appropriate prefix (`CA-AUTH-STRENGTH-*`, `CA-LOCATION-*`, etc.).
+2. Reference the artifact by display name from any CA policy template that uses it.
+3. Update this README with an entry for the new artifact.
+4. Add a CHANGELOG entry under `[Unreleased]`.


### PR DESCRIPTION
## Summary

Introduces a new `Supporting-Artifacts/` folder under the Conditional Access Baseline framework and ships the three custom authentication-strength templates that the v1.2 policy slate binds via `grantControls.authenticationStrength`. No CA policies change in this PR; this is foundation work that the policy PRs in v1.2 (CA-COV004, CA-AUT003, CA-AUT004, CA-AUT005, CA-SIG004, CA-SIG005) depend on.

## What this PR does

- Adds `Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/README.md` documenting the folder's purpose, the schema for authentication-strength templates, and how `Deploy-CABaseline.ps1` will resolve placeholder IDs against the tenant
- Adds `CA-AUTH-STRENGTH-StandardAuth.json` — Windows Hello for Business, FIDO2, or password + Microsoft Authenticator push. The default strength for general user populations during the rollout to phishing-resistant credentials.
- Adds `CA-AUTH-STRENGTH-StrongAuth.json` — Windows Hello for Business or FIDO2. Phishing-resistant only, no password-backed factors.
- Adds `CA-AUTH-STRENGTH-AdminAuth.json` — FIDO2 only. The narrowest strength in the baseline; for privileged accounts and admin roles.
- Updates CHANGELOG.md `[Unreleased]` with five new `### Added` bullets (folder + README, plus the three templates)

## Design principle cited

Principle 1 — Phishing-resistant by default, with graduated fallbacks where a full rollout is incomplete. The baseline ships three strengths covering the operational reality: StandardAuth carries general populations during the rollout to phishing-resistant credentials, StrongAuth covers post-rollout sensitive scenarios, AdminAuth is the narrowest band for privileged accounts.

## Schema notes

Templates follow the Microsoft Graph `authenticationStrengthPolicy` resource type:

- `displayName` — the exact name `Deploy-CABaseline.ps1` will match against in the tenant
- `description` — repo-side commentary; becomes the Description in the tenant on creation
- `policyType: "custom"` — distinguishes from the three built-in strengths (MFA, Passwordless MFA, Phishing-resistant MFA)
- `requirementsSatisfied: "mfa"` — all three satisfy the MFA grant control
- `allowedCombinations` — the list of allowed authentication method combinations

Server-side fields (`id`, `createdDateTime`, `modifiedDateTime`, `combinationConfigurations`) are omitted from templates and populated by Graph at creation time.

## Why now

The v1.2 policy slate cannot ship without these templates. Policy templates in later PRs will reference `REPLACE_WITH_AUTH_STRENGTH_*_ID` placeholders that resolve against these display names. Landing the templates first keeps each policy PR a single logical change.

## Checklist

- [x] Design-principle citation in the PR description
- [x] CHANGELOG entry under `[Unreleased]`
- [x] Markdownlint clean
- [x] No real tenant IDs (auth-strength templates carry no tenant IDs by design; resolved by `displayName` at deploy time)
- [x] One logical change per PR (three templates that ship as a unit because they are conceptually inseparable — the strength tiers cover one design choice)
- [x] N/A — no CA policy JSON added in this PR, so the `Deploy-CABaseline.ps1 -WhatIf` parse check is not applicable

Closes #30  