### PR TITLE
feat: add CA-LOCATION-TrustedCountries template and named-location de…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to **M365-Security-Frameworks** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+---
+
 ## [Unreleased]
 
 ### Added
@@ -14,10 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-StandardAuth.json — custom authentication strength: Windows Hello for Business, FIDO2, or password + Microsoft Authenticator push. Default strength for general user populations during the rollout to phishing-resistant credentials.
 - Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-StrongAuth.json — custom authentication strength: Windows Hello for Business or FIDO2. Phishing-resistant only.
 - Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-AdminAuth.json — custom authentication strength: FIDO2 only. Narrowest strength in the baseline; for privileged accounts and admin roles.
+- Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-LOCATION-TrustedCountries.json — country-based named location template (`countryNamedLocation`). Default scope: US, `clientIpAddress` lookup, unknown countries excluded. Adopters customize the `countriesAndRegions` list to match their organization's trust posture before bootstrapping.
+- Frameworks/Conditional-Access-Baseline/Scripts/Deploy-CABaseline.ps1 — added `Resolve-NamedLocationId` resolver, new `-SupportingArtifactsPath` and `-TrustedCountriesLocationName` parameters, and a new `REPLACE_WITH_TRUSTED_COUNTRIES_LOCATION_ID` substitution. The deployer now resolves named-location placeholders against `/identity/conditionalAccess/namedLocations` by display name.
+- Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/README.md — added named-locations section and a bootstrapping-artifacts section with the Graph API calls operators run once per tenant to provision custom authentication strengths and named locations before deployment.
 
 ### Fixed
 
-- Top-level `README.md` — Frameworks table status for the Conditional Access Baseline updated from `v1.0.0` to `v1.1.0` to match the v1.1.0 release. Documentation-only correction; missed during the v1.1.0 release prep.## [1.1.0] — 2026-05-01
+- Top-level `README.md` — Frameworks table status for the Conditional Access Baseline updated from `v1.0.0` to `v1.1.0` to match the v1.1.0 release. Documentation-only correction; missed during the v1.1.0 release prep.
+
+---
+
+## [1.1.0] — 2026-05-01
 
 Operational maturity and persona completeness release for the **Conditional Access Baseline**. Adds the External Guests and Workload Identities personas, a written Emergency Access exclusion contract, a report-only telemetry script, repo governance scaffolding, and a hardened deployer.
 

--- a/Frameworks/Conditional-Access-Baseline/Scripts/Deploy-CABaseline.ps1
+++ b/Frameworks/Conditional-Access-Baseline/Scripts/Deploy-CABaseline.ps1
@@ -3,19 +3,34 @@
     Deploys the Conditional Access Baseline policies to a Microsoft Entra tenant.
 
 .DESCRIPTION
-    Deploy-CABaseline.ps1 imports the six CA-COV, CA-SIG, and CA-AUT policy
+    Deploy-CABaseline.ps1 imports the CA-COV, CA-SIG, and CA-AUT policy
     templates in this framework into the target tenant. The script:
 
     - Resolves tenant-specific placeholders (persona group IDs, authentication
-      strength ID) by looking them up in the tenant at runtime
+      strength IDs, named location IDs) by looking them up in the tenant at
+      runtime
     - Validates every placeholder resolves before submitting any policy
     - Defaults to report-only state (enabledForReportingButNotEnforced); use
       -Enforce to promote to enabled state (requires explicit confirmation)
     - Supports -WhatIf for safe preview before any policy is created
 
+    Supporting artifacts (custom authentication strengths, named locations)
+    referenced by the policy templates must exist in the tenant before running
+    this script. The Supporting-Artifacts folder in this framework contains the
+    JSON templates that document the expected shape of each artifact; operators
+    provision them once via the Graph API (see Supporting-Artifacts/README.md),
+    and this script resolves them by display name at deploy time.
+
 .PARAMETER PolicyPath
     Path to the folder containing the JSON policy templates. Defaults to
     '../Policies' relative to the script's location.
+
+.PARAMETER SupportingArtifactsPath
+    Path to the folder containing JSON templates for supporting artifacts
+    (custom authentication strengths, named locations). Defaults to
+    '../Supporting-Artifacts' relative to the script's location. This folder is
+    not deployed by the script; it documents the expected shape of artifacts
+    that must pre-exist in the tenant.
 
 .PARAMETER EmergencyAccessGroupName
     Display name of the emergency access group. Default: CA-Persona-EmergencyAccess.
@@ -32,6 +47,10 @@
 .PARAMETER AuthStrengthName
     Display name of the authentication strength policy. Default: 'Phishing-resistant MFA'.
 
+.PARAMETER TrustedCountriesLocationName
+    Display name of the trusted-countries named location. Default: 'Trusted Countries'.
+    Template: ../Supporting-Artifacts/CA-LOCATION-TrustedCountries.json.
+
 .PARAMETER Enforce
     Switch. If specified, policies are created in 'enabled' state instead of
     report-only. Destructive — requires explicit confirmation.
@@ -42,21 +61,22 @@
 
 .EXAMPLE
     .\Deploy-CABaseline.ps1
-    Deploy all six policies in report-only mode.
+    Deploy all policies in report-only mode.
 
 .EXAMPLE
     .\Deploy-CABaseline.ps1 -Enforce
-    Deploy all six policies in enabled state. Prompts for confirmation.
+    Deploy all policies in enabled state. Prompts for confirmation.
 
 .NOTES
     Requires:
     - PowerShell 7.0 or later
     - Microsoft.Graph PowerShell SDK 2.x
-    - Graph scopes: Policy.ReadWrite.ConditionalAccess, Group.Read.All, Policy.Read.All
-    - Persona groups must exist in the tenant before running this script
+    - Graph scopes: Policy.ReadWrite.ConditionalAccess, Group.Read.All, Policy.Read.All, Application.Read.All
+    - Persona groups, authentication strengths, and named locations must exist
+      in the tenant before running this script
 
     Connect with:
-      Connect-MgGraph -Scopes Policy.ReadWrite.ConditionalAccess,Group.Read.All,Policy.Read.All
+      Connect-MgGraph -Scopes Policy.ReadWrite.ConditionalAccess,Group.Read.All,Policy.Read.All,Application.Read.All
 
     Author: Derek Morgan, Cloud Harbor Consulting
     Repository: https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks
@@ -66,6 +86,9 @@
 param(
     [Parameter()]
     [string]$PolicyPath = (Join-Path $PSScriptRoot 'Policies'),
+
+    [Parameter()]
+    [string]$SupportingArtifactsPath = (Join-Path $PSScriptRoot 'Supporting-Artifacts'),
 
     [Parameter()]
     [string]$EmergencyAccessGroupName = 'CA-Persona-EmergencyAccess',
@@ -81,6 +104,9 @@ param(
 
     [Parameter()]
     [string]$AuthStrengthName = 'Phishing-resistant MFA',
+
+    [Parameter()]
+    [string]$TrustedCountriesLocationName = 'Trusted Countries',
 
     [Parameter()]
     [switch]$Enforce
@@ -151,6 +177,20 @@ function Resolve-AuthStrengthId {
     return $match[0].id
 }
 
+function Resolve-NamedLocationId {
+    param([Parameter(Mandatory)][string]$DisplayName)
+    $uri = 'https://graph.microsoft.com/v1.0/identity/conditionalAccess/namedLocations?$select=id,displayName'
+    $response = Invoke-MgGraphRequest -Method GET -Uri $uri
+    $match = @($response.value | Where-Object { $_.displayName -eq $DisplayName })
+    if ($match.Count -eq 0) {
+        throw "Named location not found in tenant: '$DisplayName'. Create it before running this script (see Supporting-Artifacts/README.md)."
+    }
+    if ($match.Count -gt 1) {
+        throw "Multiple named locations found with displayName '$DisplayName'. Ensure the name is unique."
+    }
+    return $match[0].id
+}
+
 function Expand-Placeholders {
     param(
         [Parameter(Mandatory)][string]$JsonContent,
@@ -191,11 +231,12 @@ try {
         'REPLACE_WITH_GLOBAL_ADMINS_GROUP_OBJECT_ID'        = Resolve-GroupId -DisplayName $GlobalAdminsGroupName
         'REPLACE_WITH_INTERNAL_USERS_GROUP_OBJECT_ID'       = Resolve-GroupId -DisplayName $InternalUsersGroupName
         'REPLACE_WITH_PHISHING_RESISTANT_MFA_STRENGTH_ID'   = Resolve-AuthStrengthId -DisplayName $AuthStrengthName
+        'REPLACE_WITH_TRUSTED_COUNTRIES_LOCATION_ID'        = Resolve-NamedLocationId -DisplayName $TrustedCountriesLocationName
     }
     foreach ($key in $substitutions.Keys) {
         Write-Status "  $key -> $($substitutions[$key])" -Level Success
     }
-
+    
     $resolvedPolicyPath = Resolve-Path -Path $PolicyPath -ErrorAction SilentlyContinue
     if (-not $resolvedPolicyPath) {
         throw "Policy path not found: $PolicyPath"

--- a/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-LOCATION-TrustedCountries.json
+++ b/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-LOCATION-TrustedCountries.json
@@ -1,0 +1,9 @@
+{
+  "displayName": "Trusted Countries",
+  "@odata.type": "#microsoft.graph.countryNamedLocation",
+  "countriesAndRegions": [
+    "US"
+  ],
+  "includeUnknownCountriesAndRegions": false,
+  "countryLookupMethod": "clientIpAddress"
+}

--- a/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/README.md
+++ b/Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/README.md
@@ -1,6 +1,6 @@
 # Conditional Access Baseline — Supporting Artifacts
 
-Tenant-scoped artifacts that CA policy templates depend on. These are not Conditional Access policies; they are prerequisites that must exist (or be created) in the tenant before the policies that reference them can be deployed.
+Tenant-scoped artifacts that CA policy templates depend on. These are not Conditional Access policies; they are prerequisites that must exist in the tenant before the policies that reference them can be deployed.
 
 Each artifact is shipped as a Graph-API-shaped JSON template, parallel to the CA policy templates in `../Policies/`.
 
@@ -14,11 +14,45 @@ Three custom authentication strengths that the v1.2 policy slate binds via `gran
 | CA-AUTH-STRENGTH-StrongAuth.json | Windows Hello for Business, FIDO2 | Phishing-resistant only. No password-backed factors. Use for sensitive scenarios where the rollout to phishing-resistant credentials is complete. |
 | CA-AUTH-STRENGTH-AdminAuth.json | FIDO2 only | The narrowest strength in the baseline. Use for privileged accounts and admin roles. No Windows Hello, no password-backed factors. |
 
-`Deploy-CABaseline.ps1` (extended in a later v1.2 PR) will resolve each `REPLACE_WITH_AUTH_STRENGTH_*_ID` placeholder in the policy templates against the tenant's `/policies/authenticationStrengthPolicies` collection, matching by `displayName`. If a custom strength does not exist, the deployer creates it from the template before policy deployment.
+## Named locations (v1.2)
+
+| Artifact | Type | Purpose |
+|----------|------|---------|
+| CA-LOCATION-TrustedCountries.json | `countryNamedLocation` | Country-based named location used by location-pinning policies (`CA-COV008` BlockByLocation; `CA-COV010` ServiceAccounts BlockUntrustedLocations). Default scope: US, `clientIpAddress` lookup, unknown countries excluded. Customize the `countriesAndRegions` list to match your organization's trust posture before bootstrapping. |
+
+## Resolution by Deploy-CABaseline.ps1
+
+`Deploy-CABaseline.ps1` resolves each placeholder (`REPLACE_WITH_*_GROUP_OBJECT_ID`, `REPLACE_WITH_*_STRENGTH_ID`, `REPLACE_WITH_*_LOCATION_ID`) in the policy templates against the tenant at deploy time, matching by **display name**. The deployer does not create the supporting artifacts themselves; operators provision them in the tenant once before running the script. The JSON templates in this folder document the exact shape each artifact should take.
+
+## Bootstrapping artifacts
+
+For each artifact in this folder, create it in the tenant once using the Graph API. Run from a PowerShell 7 session connected with `Connect-MgGraph -Scopes Policy.ReadWrite.ConditionalAccess`.
+
+### Custom authentication strengths (run once per template)
+
+```powershell
+$body = Get-Content -Path .\CA-AUTH-STRENGTH-StandardAuth.json -Raw
+Invoke-MgGraphRequest -Method POST `
+    -Uri 'https://graph.microsoft.com/v1.0/policies/authenticationStrengthPolicies' `
+    -Body $body -ContentType 'application/json'
+```
+
+Repeat for `CA-AUTH-STRENGTH-StrongAuth.json` and `CA-AUTH-STRENGTH-AdminAuth.json`.
+
+### Country named location
+
+```powershell
+$body = Get-Content -Path .\CA-LOCATION-TrustedCountries.json -Raw
+Invoke-MgGraphRequest -Method POST `
+    -Uri 'https://graph.microsoft.com/v1.0/identity/conditionalAccess/namedLocations' `
+    -Body $body -ContentType 'application/json'
+```
 
 ## Schema
 
-Authentication-strength templates follow the Microsoft Graph schema for `authenticationStrengthPolicy`:
+### Authentication strengths
+
+Templates follow the Microsoft Graph `authenticationStrengthPolicy` schema:
 
 - `displayName` — exact name the deployer matches against
 - `description` — repo-side commentary explaining when to use the strength
@@ -27,6 +61,16 @@ Authentication-strength templates follow the Microsoft Graph schema for `authent
 - `requirementsSatisfied` — always `mfa`
 
 Server-side fields (`id`, `createdDateTime`, `modifiedDateTime`, `combinationConfigurations`) are omitted from templates.
+
+### Named locations
+
+Templates follow the Microsoft Graph `namedLocation` schema:
+
+- `displayName` — exact name the deployer matches against
+- `@odata.type` — discriminator (`#microsoft.graph.countryNamedLocation` or `#microsoft.graph.ipNamedLocation`)
+- Type-specific properties: for country locations, `countriesAndRegions`, `countryLookupMethod`, `includeUnknownCountriesAndRegions`; for IP locations, `ipRanges`, `isTrusted`
+
+Server-side fields (`id`, `createdDateTime`, `modifiedDateTime`) are omitted from templates.
 
 ## Adding a new artifact
 


### PR DESCRIPTION
## Summary

Ships the country named-location template that the v1.2 location-pinning policies (CA-COV008 BlockByLocation, CA-COV010 ServiceAccounts BlockUntrustedLocations) will bind against, and extends `Deploy-CABaseline.ps1` to resolve named-location placeholders by display name. No CA policies change in this PR; this is foundation work that PR 7 (CA-COV008) and PR 14 (CA-COV010) depend on.

## What this PR does

- Adds `Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-LOCATION-TrustedCountries.json` — `countryNamedLocation` template with `US` as the default country, `clientIpAddress` lookup, and unknown countries excluded
- Adds a `Resolve-NamedLocationId` function to `Deploy-CABaseline.ps1` that queries `/identity/conditionalAccess/namedLocations` and matches by display name (parallel in shape to the existing `Resolve-GroupId` and `Resolve-AuthStrengthId` resolvers)
- Adds two new script parameters: `-SupportingArtifactsPath` (default `../Supporting-Artifacts`) and `-TrustedCountriesLocationName` (default `Trusted Countries`)
- Adds the `REPLACE_WITH_TRUSTED_COUNTRIES_LOCATION_ID` placeholder to the substitutions hashtable so the v1.2 policy templates can resolve their location reference at deploy time
- Updates the comment-based help (SYNOPSIS, DESCRIPTION, .PARAMETER, .NOTES) to reflect the named-location capability
- Updates `Supporting-Artifacts/README.md` with a named-locations section and a new bootstrapping-artifacts section documenting the Graph API calls operators run once per tenant to provision both authentication strengths and named locations

## Design principle cited

Principle 3 — Compensating controls anchored to verifiable signals (location, device, risk) rather than to credential strength alone. The named-location template is the signal anchor for the two v1.2 location-pinning policies. Centralizing it as a single tenant-scoped artifact means both policies bind to the same source of truth, and adopters customize the trust posture once.

## Loader design notes

- The deployer **resolves** supporting artifacts (it does not create them). Operators bootstrap each artifact in their tenant once using the Graph API calls documented in `Supporting-Artifacts/README.md`. This is consistent with the existing pattern for persona groups and authentication strengths.
- `Resolve-NamedLocationId` throws a clear error if the named location is not found in the tenant, pointing the operator at the README. This matches the failure shape of `Resolve-GroupId` and `Resolve-AuthStrengthId`.
- Required Graph scopes are unchanged. Named-location reads are covered by the existing `Policy.Read.All`.

## Backward compatibility

- v1.1 policies do not reference `REPLACE_WITH_TRUSTED_COUNTRIES_LOCATION_ID`, so adding the substitution does not affect existing deployments.
- However, the script now requires the `Trusted Countries` named location to exist in the tenant (because resolution runs before any policy is processed). Adopters upgrading from v1.1 who have not yet bootstrapped the named location will see a clear failure at the resolution step. The README documents the one-time bootstrap.

## Why now

The v1.2 location-pinning policies cannot ship without this template and the resolver wiring. Landing both pieces first keeps each downstream policy PR a single logical change.

## Checklist

- [x] Design-principle citation in the PR description
- [x] CHANGELOG entry under `[Unreleased]`
- [x] Markdownlint clean
- [x] No real tenant IDs (named-location template carries no tenant IDs by design; resolved by `displayName` at deploy time)
- [x] One logical change per PR (the template and the resolver wiring are conceptually inseparable — the template documents the artifact the resolver looks up)
- [x] `Deploy-CABaseline.ps1 -WhatIf` still parses every existing v1.1 policy template (no policy templates added in this PR; substitution map only grows)

Closes #31 