### PR TITLE
Add CA-COV008-Global-BlockByLocation policy template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CA-COV008-Global-BlockByLocation policy template (Global persona; blocks sign-ins from locations outside the CA-LOCATION-TrustedCountries named-location set; report-only on first deployment; excludes EmergencyAccess, WorkloadIdentities, and ServiceAccounts groups).
 - Frameworks/Conditional-Access-Baseline/Policies/CA-EXC002-ServiceAccounts-Exclusion.md — written contract documenting that every human-targeted CA-* policy excludes the ServiceAccounts persona via `users.excludeGroups`, and that the persona is the inclusion target for the v1.2 compensating control (CA-COV010-ServiceAccounts-BlockUntrustedLocations). Defines persona membership rules, monthly attestation, quarterly sign-in review, and credential rotation procedure. Parallel in structure to CA-EXC001-EmergencyAccess-Exclusion.md.
 - Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/ — new folder for tenant-scoped artifacts that CA policy templates depend on (custom authentication strengths, named locations). Includes a README documenting the schema and how `Deploy-CABaseline.ps1` will resolve placeholder IDs against the tenant.
 - Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/CA-AUTH-STRENGTH-StandardAuth.json — custom authentication strength: Windows Hello for Business, FIDO2, or password + Microsoft Authenticator push. Default strength for general user populations during the rollout to phishing-resistant credentials.

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-COV008-Global-BlockByLocation.json
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-COV008-Global-BlockByLocation.json
@@ -1,0 +1,28 @@
+{
+  "displayName": "CA-COV008-Global-BlockByLocation",
+  "state": "enabledForReportingButNotEnforced",
+  "conditions": {
+    "users": {
+      "includeUsers": ["All"],
+      "excludeGroups": [
+        "REPLACE_WITH_EMERGENCY_ACCESS_GROUP_OBJECT_ID",
+        "REPLACE_WITH_WORKLOAD_IDENTITIES_GROUP_OBJECT_ID",
+        "REPLACE_WITH_SERVICE_ACCOUNTS_GROUP_OBJECT_ID"
+      ]
+    },
+    "applications": {
+      "includeApplications": ["All"]
+    },
+    "locations": {
+      "includeLocations": ["All"],
+      "excludeLocations": [
+        "REPLACE_WITH_TRUSTED_COUNTRIES_LOCATION_OBJECT_ID"
+      ]
+    },
+    "clientAppTypes": ["all"]
+  },
+  "grantControls": {
+    "operator": "OR",
+    "builtInControls": ["block"]
+  }
+}


### PR DESCRIPTION
## Summary

Adds CA-COV008-Global-BlockByLocation to the Conditional Access Baseline. Global persona policy that blocks sign-ins from any location outside the trusted countries named-location set defined in CA-LOCATION-TrustedCountries (shipped in v1.2 Phase 1 PR 3).

## Design principle

Defense in depth via location-based coverage. Pairs with identity-strength controls (AUT002, AUT003, AUT004) and platform coverage (COV007) to narrow the attack surface to expected geographies. Report-only on first deployment; tenant operators flip to enforce after telemetry review via Get-CABaselineImpact.ps1.

## Changes

- New file: Policies/CA-COV008-Global-BlockByLocation.json
- CHANGELOG.md: one line added under [Unreleased] ### Added

## Policy shape

- State: enabledForReportingButNotEnforced (report-only)
- Include users: All
- Exclude groups: EmergencyAccess (EXC001), WorkloadIdentities, ServiceAccounts (EXC002)
- Include applications: All
- Include locations: All
- Exclude locations: CA-LOCATION-TrustedCountries (named location from PR 3)
- Client app types: all
- Grant control: block

## Verification

- Deploy-CABaseline.ps1 -WhatIf parses the new template
- Markdownlint clean (CHANGELOG entry)
- Placeholder IDs only (REPLACE_WITH_*_OBJECT_ID)

Closes #35 