### PR TITLE
Add CA-AUT003 RegisterDevice and CA-AUT004 RegisterSecurityInfo userAction pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CA-AUT003-Global-RegisterDevice policy template (Global persona; userAction urn:user:registerdevice; requires StandardAuth authentication strength; report-only on first deployment; excludes EmergencyAccess, WorkloadIdentities, and ServiceAccounts groups).
+- CA-AUT004-Global-RegisterSecurityInfo policy template (Global persona; userAction urn:user:registersecurityinfo; requires StandardAuth authentication strength; report-only on first deployment; excludes EmergencyAccess, WorkloadIdentities, and ServiceAccounts groups).
 - CA-COV008-Global-BlockByLocation policy template (Global persona; blocks sign-ins from locations outside the CA-LOCATION-TrustedCountries named-location set; report-only on first deployment; excludes EmergencyAccess, WorkloadIdentities, and ServiceAccounts groups).
 - Frameworks/Conditional-Access-Baseline/Policies/CA-EXC002-ServiceAccounts-Exclusion.md — written contract documenting that every human-targeted CA-* policy excludes the ServiceAccounts persona via `users.excludeGroups`, and that the persona is the inclusion target for the v1.2 compensating control (CA-COV010-ServiceAccounts-BlockUntrustedLocations). Defines persona membership rules, monthly attestation, quarterly sign-in review, and credential rotation procedure. Parallel in structure to CA-EXC001-EmergencyAccess-Exclusion.md.
 - Frameworks/Conditional-Access-Baseline/Supporting-Artifacts/ — new folder for tenant-scoped artifacts that CA policy templates depend on (custom authentication strengths, named locations). Includes a README documenting the schema and how `Deploy-CABaseline.ps1` will resolve placeholder IDs against the tenant.

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-AUT003-Global-RegisterDevice.json
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-AUT003-Global-RegisterDevice.json
@@ -1,0 +1,25 @@
+{
+  "displayName": "CA-AUT003-Global-RegisterDevice",
+  "state": "enabledForReportingButNotEnforced",
+  "conditions": {
+    "users": {
+      "includeUsers": ["All"],
+      "excludeGroups": [
+        "REPLACE_WITH_EMERGENCY_ACCESS_GROUP_OBJECT_ID",
+        "REPLACE_WITH_WORKLOAD_IDENTITIES_GROUP_OBJECT_ID",
+        "REPLACE_WITH_SERVICE_ACCOUNTS_GROUP_OBJECT_ID"
+      ]
+    },
+    "applications": {
+      "includeUserActions": ["urn:user:registerdevice"]
+    },
+    "clientAppTypes": ["all"]
+  },
+  "grantControls": {
+    "operator": "AND",
+    "builtInControls": [],
+    "authenticationStrength": {
+      "id": "REPLACE_WITH_STANDARD_AUTH_STRENGTH_ID"
+    }
+  }
+}

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-AUT004-Global-RegisterSecurityInfo.json
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-AUT004-Global-RegisterSecurityInfo.json
@@ -1,0 +1,25 @@
+{
+  "displayName": "CA-AUT004-Global-RegisterSecurityInfo",
+  "state": "enabledForReportingButNotEnforced",
+  "conditions": {
+    "users": {
+      "includeUsers": ["All"],
+      "excludeGroups": [
+        "REPLACE_WITH_EMERGENCY_ACCESS_GROUP_OBJECT_ID",
+        "REPLACE_WITH_WORKLOAD_IDENTITIES_GROUP_OBJECT_ID",
+        "REPLACE_WITH_SERVICE_ACCOUNTS_GROUP_OBJECT_ID"
+      ]
+    },
+    "applications": {
+      "includeUserActions": ["urn:user:registersecurityinfo"]
+    },
+    "clientAppTypes": ["all"]
+  },
+  "grantControls": {
+    "operator": "AND",
+    "builtInControls": [],
+    "authenticationStrength": {
+      "id": "REPLACE_WITH_STANDARD_AUTH_STRENGTH_ID"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds CA-AUT003-Global-RegisterDevice and CA-AUT004-Global-RegisterSecurityInfo to the Conditional Access Baseline. Both are Global persona userAction policies that require StandardAuth at the moment of identity bootstrap (device registration, security-info registration).

## Design principle

Harden identity bootstrap surfaces. Register-device and register-security-info are the two userAction events where an attacker with stolen credentials can pivot to durable persistence (rogue device join, swapped MFA method). Both controls require StandardAuth (WHfB + FIDO2 + Password+Authenticator push) so the registering principal proves possession before the credential or device is trusted.

## Pair PR rationale

Device registration and security-info registration are the two userAction surfaces the baseline covers. They ship together because the controls are conceptually one unit: harden every self-service identity bootstrap path.

## Changes

- New file: Frameworks/Conditional-Access-Baseline/Policies/CA-AUT003-Global-RegisterDevice.json
- New file: Frameworks/Conditional-Access-Baseline/Policies/CA-AUT004-Global-RegisterSecurityInfo.json
- Frameworks/Conditional-Access-Baseline/CHANGELOG.md: two lines added under [Unreleased] ### Added

## Policy shape (both)

- State: enabledForReportingButNotEnforced (report-only)
- Include users: All
- Exclude groups: EmergencyAccess (EXC001), WorkloadIdentities, ServiceAccounts (EXC002)
- Include user actions: urn:user:registerdevice (AUT003) / urn:user:registersecurityinfo (AUT004)
- Client app types: all
- Grant control: authenticationStrength = StandardAuth (from CA-AUTH-STRENGTH-StandardAuth.json, PR 2)

## Verification

- Deploy-CABaseline.ps1 -WhatIf parses both new templates
- Markdownlint clean (CHANGELOG entries)
- Placeholder IDs only (REPLACE_WITH_*_OBJECT_ID, REPLACE_WITH_STANDARD_AUTH_STRENGTH_ID)

Closes #36 