### PR TITLE
feat(ca-baseline): CA-SIG004 + CA-SIG005 graduated medium-risk response

### DIFF
--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-SIG004-Global-MediumUserRisk.json
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-SIG004-Global-MediumUserRisk.json
@@ -1,0 +1,33 @@
+{
+  "displayName": "CA-SIG004-Global-MediumUserRisk",
+  "state": "enabledForReportingButNotEnforced",
+  "conditions": {
+    "users": {
+      "includeUsers": ["All"],
+      "excludeGroups": [
+        "REPLACE_WITH_EMERGENCY_ACCESS_GROUP_OBJECT_ID",
+        "REPLACE_WITH_WORKLOAD_IDENTITIES_GROUP_OBJECT_ID",
+        "REPLACE_WITH_SERVICE_ACCOUNTS_GROUP_OBJECT_ID"
+      ]
+    },
+    "applications": {
+      "includeApplications": ["All"]
+    },
+    "userRiskLevels": ["medium"],
+    "clientAppTypes": ["all"]
+  },
+  "grantControls": {
+    "operator": "AND",
+    "builtInControls": ["passwordChange"],
+    "authenticationStrength": {
+      "id": "REPLACE_WITH_STANDARD_AUTH_STRENGTH_ID"
+    }
+  },
+  "sessionControls": {
+    "signInFrequency": {
+      "isEnabled": true,
+      "authenticationType": "primaryAndSecondaryAuthentication",
+      "frequencyInterval": "everyTime"
+    }
+  }
+}

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-SIG005-Global-MediumSignInRisk.json
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-SIG005-Global-MediumSignInRisk.json
@@ -1,0 +1,33 @@
+{
+  "displayName": "CA-SIG005-Global-MediumSignInRisk",
+  "state": "enabledForReportingButNotEnforced",
+  "conditions": {
+    "users": {
+      "includeUsers": ["All"],
+      "excludeGroups": [
+        "REPLACE_WITH_EMERGENCY_ACCESS_GROUP_OBJECT_ID",
+        "REPLACE_WITH_WORKLOAD_IDENTITIES_GROUP_OBJECT_ID",
+        "REPLACE_WITH_SERVICE_ACCOUNTS_GROUP_OBJECT_ID"
+      ]
+    },
+    "applications": {
+      "includeApplications": ["All"]
+    },
+    "signInRiskLevels": ["medium"],
+    "clientAppTypes": ["all"]
+  },
+  "grantControls": {
+    "operator": "AND",
+    "builtInControls": [],
+    "authenticationStrength": {
+      "id": "REPLACE_WITH_STANDARD_AUTH_STRENGTH_ID"
+    }
+  },
+  "sessionControls": {
+    "signInFrequency": {
+      "isEnabled": true,
+      "authenticationType": "primaryAndSecondaryAuthentication",
+      "frequencyInterval": "everyTime"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the two medium-risk graduated-response policies under the Global persona. CA-SIG004 covers medium User Risk and requires StandardAuth plus a password change. CA-SIG005 covers medium Sign-In Risk and requires StandardAuth. Both policies set sign-in frequency to every time so the elevated friction is applied per attempt rather than amortized across a session.

## Changes

- Frameworks/Conditional-Access-Baseline/Policies/CA-SIG004-Global-MediumUserRisk.json (new)
- Frameworks/Conditional-Access-Baseline/Policies/CA-SIG005-Global-MediumSignInRisk.json (new)
- CHANGELOG.md (Unreleased entry for both policies)

## Design principle

Graduated response (POLICY-DESIGN.md). Medium-risk signals do not block; they elevate the auth requirement and force re-authentication. SIG004 pairs the user-risk signal with a password change to remediate a likely-compromised credential while preserving access. SIG005 treats medium sign-in risk as a per-attempt control without remediation, because the signal is about the session shape, not the identity. Pairing the two policies in one PR keeps the medium-risk surface atomic; covering one but not the other would leave a graduated-response gap until the second policy lands.

## Test plan

- Deploy-CABaseline.ps1 -WhatIf parses both templates cleanly.
- Both policies ship as enabledForReportingButNotEnforced for the report-only soak.
- Excludes EmergencyAccess, WorkloadIdentities, ServiceAccounts groups (Global persona pattern).
- StandardAuth strength ID and the three exclude group object IDs use the standard REPLACE_WITH_* placeholders.

Closes #37 