### PR TITLE
docs: sync READMEs and SECURITY.md with required changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-None in this release.
+- Top-level `README.md` — Frameworks table updated to add the Security Reporting Decision Rubric Preview row. Documentation-only correction; missed when the framework was added earlier in this Unreleased cycle.
+- Frameworks/Conditional-Access-Baseline/README.md — Prerequisites line updated to remove `CA-SIG002` (removed in this same Unreleased cycle) and add `CA-SIG009` and `CA-SIG010` to the P2 Identity Protection required-for list. Documentation-only correction; missed when CA-SIG002 was removed and CA-SIG009 and CA-SIG010 were added earlier in this Unreleased cycle.
 
 ---
 

--- a/Frameworks/Conditional-Access-Baseline/README.md
+++ b/Frameworks/Conditional-Access-Baseline/README.md
@@ -139,7 +139,7 @@ Per-policy design specs (intent, principle mapping, scope, conditions, controls,
 
 ## Prerequisites
 
-- Microsoft Entra ID P1 (minimum). P2 unlocks Identity Protection (required for `CA-SIG002`, `CA-SIG004`, `CA-SIG005`, `CA-SIG006`) and Privileged Identity Management (required for `CA-AUT002`).
+- Microsoft Entra ID P1 (minimum). P2 unlocks Identity Protection (required for `CA-SIG004`, `CA-SIG005`, `CA-SIG006`, `CA-SIG009`, `CA-SIG010`) and Privileged Identity Management (required for `CA-AUT002`).
 - Microsoft Entra Workload Identities Premium (required for `CA-COV003`).
 - Microsoft Intune (required for `CA-SIG001` and `CA-COV009`; hybrid Azure AD join is an accepted alternative for both).
 - PowerShell 7 and the Microsoft Graph SDK 2.x for the deployer.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Every framework in this repo includes:
 |-----------|--------|--------|-------|
 | [Conditional Access Baseline](./Frameworks/Conditional-Access-Baseline/) | Released | v1.2.0 (2026-05-15) | 23 policies across 5 personas plus workload identities; report-only by default |
 | [Intune Compliance Baseline](./Frameworks/Intune-Compliance-Baseline/) | Preview | v0.1.0-preview (2026-05-15) | First Windows 10/11 compliance template + framework design spec; macOS, iOS, Android, Linux templates and Deploy-ICBaseline.ps1 land toward Q3 2026 full-framework completion |
+| [Security Reporting Decision Rubric](./Frameworks/Security-Reporting-Decision-Rubric/) | Preview | v0.1.0-preview (pending) | 4-question decision flow for designing audience-scoped security reports; severity floor guidance grounded in Defender XDR's severity model; 2 starter templates (board quarterly, CISO monthly) |
 | Entra ID Governance Toolkit | Planned | — | First Access Reviews automation templates Month 2 Week 2 (May 2026); full framework Q4 2026 |
 | Defender XDR Detection Rules | Planned | — | First custom KQL queries Month 7 Week 2 (Oct 2026); full framework Q1 2027 |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,7 @@ Instead, report privately via one of the following:
 - **GitHub private advisory:** Use the [Report a vulnerability](https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/security/advisories/new) button in the repo's Security tab
 
 Please include:
+
 - A description of the issue and which artifact is affected
 - Steps to reproduce or demonstrate the impact
 - Your assessment of severity (low / medium / high / critical)


### PR DESCRIPTION
Two documentation-only corrections to bring the README surface into sync with the Unreleased work already landed.

Changes:

- Top-level README.md: Frameworks table gains a Preview row for Security Reporting Decision Rubric. The framework folder and 4 files shipped under [Unreleased] on 2026-05-27 but the root table was not refreshed at the same time.
- Frameworks/Conditional-Access-Baseline/README.md: Prerequisites line drops CA-SIG002 from the P2 Identity Protection required-for list (the policy was removed earlier in this Unreleased cycle) and adds CA-SIG009 and CA-SIG010 (both P2-required for Identity Protection hard-blocks on high risk).
- CHANGELOG.md: Two Fixed entries under [Unreleased] documenting both corrections.

Why now: same pattern as the v1.2.0 release Fixed entry that synced the root README's CA Baseline status from v1.0.0 to v1.1.0. Catches the drift before the next tag rather than carrying it into v1.3.0.

No functional changes. No policy template, deployer, or supporting-artifact file is touched.