### PR TITLE
release(ca): v1.3.0 release prep — ROI rewrite, CHANGELOG, README sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+None at this time.
+
+---
+
+## [1.3.0] - 2026-05-28
+
+The v1.3 release closes the Conditional Access Baseline development cycle that began with the wholesale stack adoption sourced from Derek's demo tenant. Twenty-four starter policies now cover seven identity personas — Global, Internal, Admins, Guests, ServiceAccounts, WorkloadIdentities, and Agents — plus a Sensitive-Applications scope, bringing the baseline to full defensible coverage of every identity class that Conditional Access can reach in a Microsoft Entra ID tenant. The headline addition is the Agents persona: Microsoft Agent ID is a distinct identity class for AI agents and Copilot agents in Entra, and CA-COV011 is the first policy in this baseline to explicitly cover that surface — one that most community CA baselines still leave unaddressed as of 2026. The full stack targets the Microsoft Graph beta endpoint for all 24 policies, with three policies requiring beta for features Microsoft has not yet promoted to v1.0 (`signInFrequency: everyTime` and the Agent ID condition family), and a documented migration commitment when GA promotion completes. Four new design documents ship with this release: AGENTS-PERSONA-MODEL.md, CAE-TOKEN-PROTECTION-LAYERING.md, WORKLOAD-IDENTITY-IP-PATTERNS.md, and CA-ICB-INTEGRATION.md. The CA-SIG010-Guests-RequireToU policy adds a Terms of Use consent gate for all six B2B guest user types. All policy JSON was normalized from PascalCase SDK format to the documented REST API camelCase wire format.
+
 ### Added
 
 - Frameworks/Conditional-Access-Baseline/Design/CA-ICB-INTEGRATION.md — cross-framework integration doc covering how the v1.3 Conditional Access Baseline consumes the Intune Compliance Baseline compliance signal. Signal flow narrative with a Mermaid diagram. Documents the three CA policies that depend on ICB (CA-COV008, CA-SIG001, CA-SIG007) with per-policy ICB requirements. Failure-mode matrix covering 7 common adopter scenarios (noncompliant device, unmanaged device, lag, mid-session revocation, legacy clients, Linux gap, mobile out-of-scope). CAE interaction documented for compliance state changes during active sessions. CA-to-ICB rollout sequence in 9 steps. Cross-framework testing procedure with 5 concrete test cases. Out-of-scope disclosure.
@@ -47,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Frameworks/Conditional-Access-Baseline/README.md — Roadmap section updated to mark the CAE and Token Protection layering doc as shipped under v1.3.
 - Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md — added cross-reference from the CA-COV010-WorkloadIdentities-TrustedLocations per-policy spec to the new WORKLOAD-IDENTITY-IP-PATTERNS.md supplement.
 - Frameworks/Conditional-Access-Baseline/README.md — Roadmap section updated to mark the Workload identity IP patterns doc as shipped under v1.3.
+- Frameworks/Conditional-Access-Baseline/Business-Case/ROI-CONDITIONAL-ACCESS.md — wholesale rewrite for v1.3. Policy count updated from 23 to 24 (including CA-SIG010 ToU). New Agents persona business case section (executive-novel content). New AuthN strength enforcement-model section replacing the v1.2 always-on PrivAccounts framing. New beta-endpoint commitment section in plain language. Annual operational hours estimate updated from approximately 52 to approximately 112 hours per year, driven by the new Agents persona attestation, the Workload Identities trusted-IPs cadence, and ToU lifecycle management. Phased investment approach extended from 12 to 20 weeks.
+- Frameworks/Conditional-Access-Baseline/README.md — status banner flipped to Released v1.3.0. Roadmap section restructured: v1.3 candidates moved to Shipped; v1.4 candidates seeded.
+- Top-level README.md — Frameworks table row for Conditional Access Baseline updated from v1.2.0 (2026-05-15) to v1.3.0 (2026-05-28). Notes column refreshed for the v1.3 surface.
 
 ### Fixed
 
@@ -92,7 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Frameworks/Conditional-Access-Baseline/Business-Case/ROI-CONDITIONAL-ACCESS.md — folded the v1.2 slate into the executive ROI document. Policy count changed from "eight" to "twenty-three". Five-persona model (Global, Internal, Admins, Guests, ServiceAccounts) noted in the executive summary alongside the workload-identity policy. Expanded "What the baseline delivers" table with 15 new rows covering the v1.2 policies (CA-AUT003, CA-AUT004, CA-COV004 through CA-COV010, CA-SIG004 through CA-SIG008), grouped by persona segment. Expanded "Risk reduction framing" table to mirror. Added Token Protection client-version note and ServiceAccounts operational note to the licensing section. Added Trusted Countries named-location provisioning, three custom authentication strength provisioning steps (StandardAuth, StrongAuth, AdminAuth), and the ServiceAccounts persona group to the implementation prerequisites. Quarterly operational estimate updated from approximately 40 hours to approximately 52 hours per year to cover ServiceAccounts geography review, admin-context risk review, and expanded risk-detection tuning. Recommended investment approach Phase 3 window extended from weeks 9 to 12 to weeks 9 to 14 to accommodate the larger enforcement surface.
 - Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md — documented sections 6.9 through 6.23 (`CA-COV004`, `CA-COV005`, `CA-COV006`, `CA-COV007`, `CA-AUT003`, `CA-AUT004`, `CA-COV008`, `CA-COV009`, `CA-SIG004`, `CA-SIG005`, `CA-AUT005`, `CA-SIG006`, `CA-SIG007`, `CA-COV010`, `CA-SIG008`) per-policy specs; added rollout-sequence rows 9 through 23; added the Service Accounts persona row to section 3 and the `CA-EXC002` reference under section 4.1 (permanent exclusions count updated from 2 to 3); added section 1.5 (v1.2 design refinements) and section 1.6 (Global and Admins scope definitions); updated section 6 intro count from "eight" to "twenty-three" starter policies.
-  
+
 ### Fixed
 
 - Top-level `README.md` — Frameworks table status for the Conditional Access Baseline updated from `v1.0.0` to `v1.1.0` to match the v1.1.0 release. Documentation-only correction; missed during the v1.1.0 release prep.
@@ -192,7 +203,10 @@ First public release of the **Conditional Access Baseline** framework.
 This framework was shaped by the public work of Joey Verlinden, Daniel Chronlund, and Claus Jespersen on Conditional Access design patterns.
 
 ---
-[Unreleased] : <https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/compare/v1.2.0...HEAD>
+
+[Unreleased]: <https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/compare/v1.3.0...HEAD>
+
+[1.3.0]: <https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/compare/v1.2.0...v1.3.0>
 
 [1.2.0] : <https://github.com/Cloud-Harbor-Consulting-LLC/M365-Security-Frameworks/compare/v1.1.0...v1.2.0>
 

--- a/Frameworks/Conditional-Access-Baseline/Business-Case/ROI-CONDITIONAL-ACCESS.md
+++ b/Frameworks/Conditional-Access-Baseline/Business-Case/ROI-CONDITIONAL-ACCESS.md
@@ -6,25 +6,35 @@
 
 Identity is the modern enterprise perimeter. Over the last five years, industry data from Verizon's annual *Data Breach Investigations Report (DBIR)*, IBM's annual *Cost of a Data Breach Report*, and the *Microsoft Digital Defense Report* consistently ranks stolen or misused credentials as the leading initial access vector for enterprise breaches. Organizations that deploy a mature Conditional Access baseline materially reduce the probability of credential-driven incidents, without adding meaningful user friction when scoped correctly.
 
-This baseline delivers twenty-three Conditional Access policies across five user personas (Global, Internal, Admins, Guests, ServiceAccounts), plus a workload-identity policy that closes the machine-sign-in coverage gap. Policies are designed to close the access paths attackers exploit most frequently: legacy authentication, unprotected privileged accounts, unmanaged endpoints accessing sensitive data, high-risk sign-ins, post-MFA token replay, untrusted geographies, and orphaned service-account credentials. Routine user workflows remain untouched.
+This v1.3 baseline delivers twenty-four Conditional Access policies across seven personas — Global, Internal, Admins, Guests, ServiceAccounts, WorkloadIdentities, and Agents — plus a Sensitive-Applications scope. Every policy ships in report-only by default. Operators promote to enforcement on a documented soak schedule, with a minimum of seven to fourteen days of impact validation per policy before any enforcement decision is made.
+
+Three developments distinguish v1.3 from prior releases and define its executive narrative:
+
+**The Agents persona.** Microsoft Agent ID is a distinct identity class in Microsoft Entra ID for AI agents and Copilot agents. Agent IDs cannot be governed by user-targeted Conditional Access policies. Without a dedicated Agents lane, agentic AI workloads run completely outside the Conditional Access policy surface — even in tenants that have otherwise deployed a mature identity baseline. The v1.3 baseline introduces CA-COV011, which covers Agent ID sign-ins via Microsoft Identity Protection signals, making this one of the first community Conditional Access baselines to include native Agent ID coverage as of 2026.
+
+**Microsoft Graph beta endpoint commitment.** Three policies require the beta endpoint because Microsoft has not yet completed general availability promotion of specific features as of May 2026: the `signInFrequency: everyTime` interval used in the risk policies, and the Microsoft Agent ID condition family used in the Agents persona policy. For operational simplicity, all twenty-four policies target the beta endpoint consistently, with a documented migration path when Microsoft completes GA promotion.
+
+**A graduated authentication strength model.** The v1.3 model replaces the v1.2 framing of always-on phishing-resistant MFA for privileged accounts with three distinct authentication strength tiers, applied at the moment and context where each tier adds the most coverage: StandardAuth at registration time for all users, AdminAuth (FIDO2 only) on admin portal surfaces for privileged roles, and StrongAuth (FIDO2 or Windows Hello for Business) on risk-elevated sessions for any user.
 
 The ask of executive leadership is threefold:
 
-1. **Endorse a phased deployment** that runs each policy in report-only mode for 7 to 14 days before enforcement.
-2. **Fund or confirm Entra ID P1 (minimum) or P2 (recommended)** licensing for all in-scope users, plus Microsoft Entra Workload Identities Premium for the workload-identity policy.
+1. **Endorse a phased deployment** that runs each policy in report-only mode for seven to fourteen days before enforcement.
+2. **Fund or confirm** Entra ID P1 (minimum) or P2 (recommended) licensing for all in-scope users, plus Microsoft Entra Workload Identities Premium for the workload-identity policy and Microsoft Agent ID feature availability for the Agents persona policy.
 3. **Authorize a quarterly review cadence** for the baseline, led jointly by Security and IT Operations.
 
-In return, the organization gets a defensible, auditable identity security posture that addresses the single highest-probability breach vector and aligns with SOC 2, ISO 27001, HIPAA, and PCI-DSS access control requirements.
+In return, the organization gets a defensible, auditable identity security posture that addresses the single highest-probability breach vector in contemporary incident data, extends coverage to the agentic AI workload surface that most frameworks ignore, and aligns with SOC 2, ISO 27001, HIPAA, PCI-DSS, and NIST SP 800-53 access control requirements. This baseline pairs with the Intune Compliance Baseline to deliver end-to-end device-health signal integration (see `Design/CA-ICB-INTEGRATION.md`).
 
 ## The business risk this addresses
 
 ### Identity compromise is the dominant breach vector
 
-Every year since the publication of the Verizon DBIR began tracking credential-based attacks as a distinct category, stolen or misused credentials have ranked among the top initial access vectors across industries and organization sizes. Phishing, password spray, adversary-in-the-middle (AiTM) token theft, and re-use of credentials exposed in third-party breaches all converge on the same point of failure: an identity that authenticates successfully with insufficient verification.
+Every year since the Verizon DBIR began tracking credential-based attacks as a distinct category, stolen or misused credentials have ranked among the top initial access vectors across industries and organization sizes. Phishing, password spray, adversary-in-the-middle token theft, and reuse of credentials exposed in third-party breaches all converge on the same point of failure: an identity that authenticates successfully with insufficient verification.
+
+The risk surface has grown. In 2026, the identity surface includes not only human users and service principals, but also AI agents operating under delegated permissions in Microsoft 365. Most identity security frameworks were designed before this identity class existed at scale. The v1.3 baseline is designed for the current attack surface, not the 2022 one.
 
 ### The financial exposure is substantial
 
-IBM's *Cost of a Data Breach Report* has consistently found that the global average cost of a data breach is measured in millions of US dollars, with breaches involving stolen or compromised credentials taking longer to identify and contain than average. For organizations in regulated industries (healthcare, financial services, critical infrastructure), the per-breach cost is materially higher.
+IBM's *Cost of a Data Breach Report* consistently finds that breaches involving stolen or compromised credentials take longer to identify and contain than the average breach — and that the per-breach cost is measured in millions of US dollars. For organizations in regulated industries (healthcare, financial services, critical infrastructure), the per-breach cost is materially higher.
 
 For this baseline's ROI calculation, the organization should reference its own most recent cyber-insurance questionnaire, internal risk register, or the latest published figures from IBM and Verizon to populate:
 
@@ -34,174 +44,226 @@ For this baseline's ROI calculation, the organization should reference its own m
 
 ### Legacy MFA does not close the gap alone
 
-MFA is necessary but no longer sufficient. Attackers using AiTM proxy kits (readily available on criminal marketplaces) can phish a valid MFA-protected session token in minutes and replay it to the target service. Microsoft's own guidance has shifted to phishing-resistant methods (FIDO2 security keys, Windows Hello for Business, certificate-based authentication) for privileged identities and high-value workloads. This baseline enforces that shift for the accounts attackers target first, and the v1.2 expansion binds tokens to issuing Windows devices to defeat replay even when phishing-resistant MFA was not in play.
+MFA is necessary but no longer sufficient as the sole authentication defense. Attackers using adversary-in-the-middle proxy kits can phish a valid MFA-protected session token in minutes and replay it to the target service without ever seeing the password. Microsoft's own guidance has shifted toward phishing-resistant methods (FIDO2 security keys, Windows Hello for Business) for privileged identities and high-value workloads. This baseline enforces that shift at the contexts where it matters most — admin portal access and risk-elevated sessions — and layers token binding to defeat replay even when phishing-resistant MFA was not in play on the original session.
 
 ## What the baseline delivers
 
-Twenty-three policies, each addressing a specific business risk. The table below summarizes each one in non-technical language, grouped by the persona the policy targets.
+Twenty-four policies, each addressing a specific business risk. Policies are grouped below by the persona segment they target. Columns: Policy ID, Persona, Intent, License floor, Business outcome.
 
-| Policy | Business risk addressed | User impact |
-|--------|------------------------|-------------|
-| **Global persona** | | |
-| Block legacy authentication | Eliminates authentication protocols that cannot enforce MFA and are the primary vector for password-spray attacks. | None for users on modern clients (Outlook, Teams, Microsoft 365 apps). |
-| Require MFA for all users | Ensures no identity authenticates with a password alone. Establishes the floor beneath every other control. | A second authentication step on unfamiliar devices or sessions. |
-| Step-up MFA on medium or high sign-in risk | Automatically challenges sign-ins that Entra ID Protection scores as risky (impossible travel, unfamiliar location, leaked credentials, anonymous proxy). | An additional MFA prompt during anomalous sessions. |
-| Require step-up and password change on medium user risk | Forces remediation when Identity Protection flags account-level compromise indicators. | A password reset prompt the next time the affected user signs in. |
-| Require strong authentication at device registration | Prevents an attacker who phished a password from registering a new device as a trusted enrollment point. | A strong-authentication prompt the first time a user enrolls a new device. |
-| Require strong authentication at security info registration | Prevents an attacker from swapping in a phone number or authenticator they control after stealing a password. | A strong-authentication prompt when adding or removing an MFA method. |
-| Disable persistent browser sessions | Bounds the validity of stolen browser cookies by enforcing a 4-hour browser re-authentication window. | Users re-authenticate in the browser every 4 hours. |
-| Block OAuth device code flow | Removes a phishing-friendly grant flow rarely used outside legitimate device-pairing scenarios. | None for typical user workflows. |
-| Block authentication transfer | Removes a cross-device authentication flow attackers can social-engineer into approving on the wrong endpoint. | None in normal workflows. |
-| Block sign-ins from unknown device platforms | Catches sign-ins from spoofed, headless, or obsolete platforms outside the tenant's supported fleet. | None on Windows, macOS, iOS, Android, Linux. |
-| Block sign-ins from untrusted countries | Removes geographies the business does not operate in from the attack surface. | Travelers register their location ahead of time or use approved access methods. |
-| **Internal persona** | | |
-| Require compliant or hybrid-joined device for sensitive apps | Ensures access to admin portals, email, and crown-jewel SaaS originates from a managed, healthy endpoint. | Users access sensitive apps only from organization-managed or hybrid-joined devices. |
-| Require compliant device on internal desktop platforms | Extends device-health-as-a-gate from sensitive apps to all internal sign-ins on Windows, macOS, and Linux. | Internal users sign in from organization-managed desktops. |
-| Bind tokens to the issuing Windows device (Token Protection) | Cryptographically ties refresh tokens and Primary Refresh Tokens to the device's TPM, defeating AiTM token replay and infostealer token theft. | None for users on supported Windows clients with modern auth. |
-| **Admins persona** | | |
-| Require phishing-resistant MFA for privileged accounts | Protects the accounts attackers target first against AiTM credential phishing. | Privileged users sign in with a hardware security key or Windows Hello instead of SMS. |
-| Require phishing-resistant MFA for privileged role activations | Extends the protection above to just-in-time privilege elevation via Privileged Identity Management. | Administrators activate elevated roles with phishing-resistant credentials. |
-| Require FIDO2-only authentication on admin portals | Narrows the highest-value admin surfaces (Azure portal, Microsoft Admin Portals) to phishing-resistant authentication only. | Admins use a FIDO2 key when opening admin portals. |
-| Block admin sign-ins flagged medium or high risk | Hard-blocks privileged sessions Entra ID Protection scores as risky rather than offering a step-up path. | Blocked admin sessions are remediated via a clean re-authentication. |
-| **Guests persona** | | |
-| Require MFA for guest users | Closes the gap where home-tenant authentication assurance for guest users may be weaker than the resource tenant's internal-user standard. | External collaborators complete MFA when accessing tenant resources. |
-| Block guest access to non-collaboration apps | Constrains B2B authorization scope to the apps that were shared, preventing token replay against unrelated tenant applications. | External collaborators access only the apps they were invited to. |
-| **ServiceAccounts persona** | | |
-| Block service-account sign-ins from untrusted countries | Closes the workload coverage gap created by excluding ServiceAccounts from human-targeted policies. | Service accounts authenticate only from registered egress geographies. |
-| **Workload identities** | | |
-| Block workload identity sign-ins from untrusted locations | Restricts service principal sign-ins to a defined egress, closing the workload-identity coverage gap left by user-scoped policies. | None for legitimate automation; vendor or cloud-resident workloads need their egress IPs registered. |
+### AUT series — Authentication Strength policies
 
-## Investment required
+| Policy ID | Persona | Intent | License floor | Business outcome |
+|---|---|---|---|---|
+| CA-AUT001 | Global (user action) | Require StandardAuth for device registration | Entra ID P1 | Every user reaches a phishing-resistant-capable posture at device enrollment time |
+| CA-AUT002 | Global (user action) | Require StandardAuth for security info registration | Entra ID P1 | Prevents attackers who phished a password from swapping in their own MFA method |
+| CA-AUT003 | Admins (14 directory roles) | Require AdminAuth (FIDO2 only) when accessing Azure Service Management or Microsoft Admin Portals | Entra ID P1 | Admin portal access — the highest-value attack surface in Microsoft 365 — requires a hardware security key |
 
-### Licensing
+### COV series — Identity-wide Coverage policies
 
-| Component | Minimum | Recommended |
-|-----------|---------|-------------|
-| Entra ID plan | P1 | P2 |
-| Why P2 is recommended | N/A | Unlocks Identity Protection (required for sign-in and user-risk policies) and Privileged Identity Management (required for privileged-role JIT activation) |
-| Microsoft Entra Workload Identities Premium | Required for the workload-identity policy (CA-COV003) | Required for the workload-identity policy (CA-COV003) |
+| Policy ID | Persona | Intent | License floor | Business outcome |
+|---|---|---|---|---|
+| CA-COV001 | Global | Block legacy authentication protocols | Entra ID P1 | Eliminates the password-spray attack surface entirely |
+| CA-COV002 | Global | Require MFA for every interactive sign-in | Entra ID P1 | No identity authenticates with a password alone |
+| CA-COV003 | Global | Disable persistent browser sessions; enforce 4-hour sign-in frequency on non-corp devices | Entra ID P1 | Stolen browser cookies expire within hours |
+| CA-COV004 | Global | Block OAuth 2.0 device code flow | Entra ID P1 | Removes a phishing-friendly grant flow attackers use to extract tokens from users |
+| CA-COV005 | Global | Block cross-device Authentication Transfer | Entra ID P1 | Eliminates a social-engineering vector where attackers redirect authentication to their device |
+| CA-COV006 | Global | Block sign-ins from unknown device platforms | Entra ID P1 | Catches spoofed, headless, or obsolete clients outside the supported fleet |
+| CA-COV007 | Global | Block sign-ins from outside the Trusted Countries named location | Entra ID P1 | Removes geographies the business does not operate in from the attack surface |
+| CA-COV008 | Internal | Require compliant or hybrid-joined device on Windows, macOS, and Linux | Entra ID P1 + Intune | Internal users sign in to all apps only from organization-managed, healthy desktops |
+| CA-COV009 | ServiceAccounts | Block service-account sign-ins from outside the Trusted Countries named location | Entra ID P1 | Closes the coverage gap created by the ServiceAccounts persona exclusion from human-targeted policies |
+| CA-COV010 | WorkloadIdentities | Restrict service-principal sign-ins to a defined egress | Workload Identities Premium | Closes the workload-identity coverage gap left by user-scoped policies |
+| CA-COV011 | Agents | Block Agent ID sign-ins at medium or high agent risk per Identity Protection | Entra ID P2 + Agent ID | Covers the agentic AI workload surface; most community baselines ignore Agent IDs entirely |
 
-**If P1 is already in place for all users,** the incremental licensing cost of this baseline covers the policies that require Identity Protection (sign-in risk and user-risk policies) and PIM (privileged role activation). Most of the v1.2 expansion uses P1 features.
+### SIG series — Layered Signal policies
 
-**If P2 is not yet in place,** the incremental cost per user can be calculated against the organization's existing Microsoft 365 agreement:
-
-- [INSERT: CURRENT USERS AT P1 × COST-PER-USER DELTA FROM P1 TO P2]
-
-Additional notes:
-
-- The Token Protection policy (Windows-only token binding) requires modern-auth clients and supported Windows 10/11 builds. No additional SKU is required; deploy after inventorying client versions in the tenant.
-- The ServiceAccounts persona policy requires an inventory of legitimate service-account sign-in geographies. This is an operational input, not a licensing line item.
-
-### Implementation (one-time)
-
-Implementation time varies by organization size and operational maturity. Typical engagement components:
-
-- Persona group design and creation (Global, Internal, Admins, Guests, ServiceAccounts)
-- Emergency access account provisioning and documentation
-- Device compliance baseline in Microsoft Intune (prerequisite for compliant-device policies)
-- MFA registration campaign (prerequisite for the all-users MFA policy)
-- Phishing-resistant method rollout to privileged users (prerequisite for the admin AUT-series policies)
-- Trusted Countries named location provisioning, populated with the organization's operating geographies
-- Three custom authentication strengths provisioned: StandardAuth (WHfB, FIDO2, or Password + Authenticator push), StrongAuth (WHfB or FIDO2), AdminAuth (FIDO2 only)
-- ServiceAccounts persona group provisioning, with documented membership rules and a monthly attestation
-- Report-only soak and validation (minimum 7 to 14 days per policy, parallelized)
-- Tuning and enforcement
-
-A representative estimate for a mid-market organization (500 to 5,000 users) is measured in tens of hours of security-architect time, not hundreds. For organizations above 10,000 users or with complex hybrid identity architectures, scope accordingly.
-
-### Ongoing (quarterly)
-
-- Baseline review and tuning (approximately 6 hours per quarter, expanded to cover the larger v1.2 surface)
-- Temporary exclusion audit (approximately 2 hours per quarter)
-- Risk detection tuning for sign-in and user-risk policies (approximately 3 hours per quarter, expanded for the medium-risk additions)
-- ServiceAccounts sign-in geography review (approximately 1 hour per quarter)
-- Admin-context risk and authentication-strength review (approximately 1 hour per quarter)
-
-**Total annualized operational cost after deployment:** approximately 52 hours of security-architect time per year.
+| Policy ID | Persona | Intent | License floor | Business outcome |
+|---|---|---|---|---|
+| CA-SIG001 | Sensitive-Applications | Require compliant or hybrid-joined device for Azure Service Management access by Internal users | Entra ID P1 + Intune | Sensitive admin surfaces reachable only from managed endpoints |
+| CA-SIG002 | Guests | Require MFA for every interactive guest sign-in | Entra ID P1 | Establishes a resource-tenant authentication floor independent of the guest's home-tenant posture |
+| CA-SIG003 | Global (risk) | Graduated response to medium user risk: StrongAuth plus risk remediation plus SignInFreq every time | Entra ID P2 | Forces phishing-resistant step-up and password change when account-level compromise indicators surface |
+| CA-SIG004 | Global (risk) | Graduated response to medium sign-in risk: StrongAuth plus SignInFreq every time | Entra ID P2 | Challenges anomalous sessions before they proceed; forces phishing-resistant re-authentication |
+| CA-SIG005 | Admins (14 directory roles) | Hard-block admin sign-ins at medium and high sign-in risk | Entra ID P2 | Privileged sessions at elevated risk do not get a re-challenge path; they are blocked outright |
+| CA-SIG006 | Guests | Block guest sign-ins to any application outside the Microsoft 365 collaboration set | Entra ID P1 | Constrains B2B authorization scope to the apps that were shared |
+| CA-SIG007 | Internal | Cryptographically bind refresh tokens to the issuing Windows device's TPM-protected key | Entra ID P1 | Stolen tokens cannot be replayed from any other device; defeats infostealer token theft |
+| CA-SIG008 | Global | Block all users on high user risk | Entra ID P2 | Zero tolerance for high-confidence account compromise indicators |
+| CA-SIG009 | Global | Block all users on high sign-in risk | Entra ID P2 | Zero tolerance for high-confidence session anomaly indicators |
+| CA-SIG010 | Guests | Require B2B guests to accept a Terms of Use before access is granted | Entra ID P2 | Documented consent gate for every B2B guest; supports contractual disclosure requirements |
 
 ## Risk reduction framing
 
-The baseline does not eliminate breach risk. No single control does. It does materially reduce the probability of the highest-frequency attack paths. Each policy maps to a specific reduction:
+The baseline does not eliminate breach risk. No single control does. It materially reduces the probability of the highest-frequency attack paths. The threat categories the baseline addresses:
 
-| Policy | Primary threat reduced | Secondary benefit |
-|--------|----------------------|-------------------|
-| **Global persona** | | |
-| Block legacy authentication | Password-spray attacks against IMAP, POP, SMTP AUTH endpoints | Removes an entire unauthenticated-by-MFA surface |
-| Require MFA for all users | Credential stuffing from third-party breaches | Forces MFA registration across the user base |
-| Step-up MFA on medium or high sign-in risk | Anomalous sessions flagged by Identity Protection | Creates adaptive, signal-driven defense |
-| Require step-up and password change on medium user risk | Compromised credentials in active circulation | Forces a password rotation tied to the risk event |
-| Require strong authentication at device registration | Adversary-led device registration after a password phish | Creates an authentication-strength signal at the enrollment moment |
-| Require strong authentication at security info registration | MFA method takeover (swap to attacker-controlled number or authenticator) | Hardens the security info surface that is itself the recovery path |
-| Disable persistent browser sessions | Stolen browser cookie replay on persistent sessions | Bounds session validity to a defensible window |
-| Block OAuth device code flow | OAuth device code phishing | Removes a low-friction grant flow attackers favor |
-| Block authentication transfer | Cross-device authentication social engineering | Eliminates a transfer flow attackers can redirect |
-| Block sign-ins from unknown device platforms | Sign-ins from spoofed, headless, or obsolete platforms | Catches non-business device platforms outside the supported set |
-| Block sign-ins from untrusted countries | Sign-ins from geographies the business does not operate in | Removes whole attacker origins from the surface area |
-| **Internal persona** | | |
-| Require compliant or hybrid-joined device for sensitive apps | Data exfiltration from unmanaged endpoints | Establishes device health as an access condition for high-value apps |
-| Require compliant device on internal desktop platforms | Sign-ins to internal apps from unmanaged desktops | Extends device-health-as-a-gate beyond sensitive apps |
-| Bind tokens to the issuing Windows device (Token Protection) | Post-MFA token replay (AiTM, infostealer, cookie redemption) | TPM-bound tokens are non-portable |
-| **Admins persona** | | |
-| Require phishing-resistant MFA for privileged accounts | AiTM token phishing of privileged identities | Creates audit evidence of strong admin auth |
-| Require phishing-resistant MFA for privileged role activations | PIM activation with phishable MFA | Closes the JIT-elevation gap |
-| Require FIDO2-only authentication on admin portals | Admin sign-ins to high-value portals with phishable MFA | Narrows admin authentication to FIDO2 on the riskiest surfaces |
-| Block admin sign-ins flagged medium or high risk | Admin credentials in a risk-flagged session | Hard-blocks rather than re-challenges privileged identities |
-| **Guests persona** | | |
-| Require MFA for guest users | Weak home-tenant MFA on guest identities | Establishes a resource-tenant authentication floor for B2B |
-| Block guest access to non-collaboration apps | Guest token replay against unrelated tenant apps | Constrains B2B authorization scope to the apps that were shared |
-| **ServiceAccounts persona** | | |
-| Block service-account sign-ins from untrusted countries | Service-account sign-ins from non-business geographies | Closes the workload coverage gap from the human-policy exclusion |
-| **Workload identities** | | |
-| Block workload identity sign-ins from untrusted locations | Service principal sign-ins from non-business egress IPs | Closes the workload-identity exclusion gap in the user-scoped baseline |
+**Credential theft and phishing.** CA-AUT003 requires phishing-resistant hardware keys (FIDO2) when accessing the Azure portal and Microsoft admin portals — the targets attackers prioritize in credential phishing campaigns against privileged identities. CA-SIG003, CA-SIG004, and CA-SIG005 enforce StrongAuth or hard-block on risk-elevated sessions for users and admins. CA-SIG008 and CA-SIG009 hard-block on high user and sign-in risk signals from Identity Protection. The combination removes the most common paths through which credential attacks succeed against a Microsoft Entra ID tenant.
 
-## Compliance and audit alignment
+**Post-MFA token theft.** CA-SIG007 (Token Protection) cryptographically binds refresh tokens and Primary Refresh Tokens to the issuing device's TPM-protected key, defeating post-MFA token replay attacks — including adversary-in-the-middle session-token capture, infostealer token theft, and browser cookie redemption. Stolen tokens are mathematically non-portable to any other device. The full interaction with Continuous Access Evaluation is documented in `Design/CAE-TOKEN-PROTECTION-LAYERING.md`.
 
-This baseline supports the access control requirements in every major compliance framework the organization is likely to operate under. The mapping below is representative. Organizations should validate specific control numbers against current framework revisions with their audit team.
+**B2B guest data exposure.** CA-SIG002 gates every guest sign-in behind MFA at the resource-tenant level, independent of the guest's home-tenant MFA posture. CA-SIG006 constrains guest token authorization to only the applications that were explicitly shared. CA-SIG010 adds a Terms of Use consent gate that creates a documented record of guest acknowledgment and supports regulatory and contractual disclosure requirements.
 
-| Framework | Relevant control family | How this baseline supports it |
-|-----------|------------------------|------------------------------|
-| SOC 2 (Trust Services Criteria) | CC6.1, CC6.2, CC6.3 (Logical and Physical Access) | Enforces authentication, identity access, and access restrictions based on role and context |
-| ISO/IEC 27001:2022 | A.5.15, A.5.17, A.8.2, A.8.5 (Access Control, Authentication Information, Privileged Access Rights, Secure Authentication) | Formalizes privileged access requirements and secure authentication patterns |
-| HIPAA Security Rule | §164.312(a)(1) (Access Control), §164.312(d) (Person or Entity Authentication) | Enforces authentication, authorization, and access restriction for systems handling ePHI |
-| PCI-DSS 4.0 | Requirement 7 (Restrict Access), Requirement 8 (Identify Users and Authenticate Access) | Multi-factor authentication for all users, phishing-resistant MFA for privileged users |
-| NIST SP 800-53 rev. 5 | AC-2, AC-3, IA-2, IA-5 (Account Management, Access Enforcement, Identification and Authentication, Authenticator Management) | Formalized account scoping, enforced access control, strong authenticator requirements |
+**Workload identity abuse.** CA-COV010 restricts service-principal sign-ins to a defined egress IP set, closing the workload-identity gap that user-scoped policies leave open. CA-COV009 extends parallel geography-based coverage to the ServiceAccounts persona. Operational patterns for named-location refresh, per-pipeline SPN scoping, and CI/CD runner egress management are documented in `Design/WORKLOAD-IDENTITY-IP-PATTERNS.md`.
 
-Beyond compliance, the baseline also satisfies the identity-related controls cyber-insurance carriers increasingly require as a precondition for coverage or favorable premium pricing.
+**Agentic AI workload abuse.** CA-COV011 blocks Agent ID sign-ins when Microsoft Identity Protection detects medium or high agent risk. Without this policy, agentic workloads operating through Microsoft Agent IDs can authenticate to tenant resources with no Conditional Access evaluation, even in tenants with an otherwise mature identity baseline. The design rationale, risk signal model, and operational runbook are in `Design/AGENTS-PERSONA-MODEL.md`.
+
+**Legacy auth bypass.** CA-COV001 blocks all authentication protocols that cannot enforce MFA, including IMAP, POP, SMTP AUTH, and older Exchange ActiveSync variants. This eliminates the password-spray attack surface entirely for any client still using legacy protocols.
+
+**Sign-in-flow phishing variants.** CA-COV004 blocks OAuth 2.0 device code flow, a grant flow attackers use to phish tokens from users who approve authentication on the wrong endpoint — a phishing variant that bypasses traditional URL-based defenses. CA-COV005 blocks Authentication Transfer, a cross-device authentication flow that can be social-engineered into authorizing on an attacker-controlled device.
+
+## Authentication strength enforcement model
+
+The v1.3 baseline introduces a graduated authentication strength model that replaces the v1.2 approach of always-on phishing-resistant MFA for all privileged accounts. The model applies three distinct authentication strength tiers at the moment and context where each tier provides the most coverage.
+
+**StandardAuth** (Windows Hello for Business, FIDO2, or password plus Microsoft Authenticator push) is required on the two user-action registration policies — CA-AUT001 (register device) and CA-AUT002 (register security info). These are the two moments where an attacker who has phished a password can do the most lasting damage: enrolling a new device or swapping in an MFA method they control. StandardAuth at these moments ensures that every user reaches a phishing-resistant-capable posture before they can modify their authentication surface.
+
+**AdminAuth** (FIDO2 only) is required by CA-AUT003 when the fourteen highly-privileged Entra ID directory roles access Azure Service Management or Microsoft Admin Portals. This narrows the two highest-value admin surfaces to phishing-resistant hardware keys, while not imposing FIDO2 on routine admin work outside those application scopes, where CA-COV002 (RequireMFA) provides the authentication floor.
+
+**StrongAuth** (Windows Hello for Business or FIDO2) is required by CA-SIG003 (medium user risk) and CA-SIG004 (medium sign-in risk) when Identity Protection signals elevate session risk. Risk-elevated sessions must clear a phishing-resistant bar before proceeding or receiving risk remediation credit.
+
+**PIM activation** is assumed to enforce always-on phishing-resistant MFA at role activation time, outside the Conditional Access baseline's scope. Adopters who have not deployed PIM should extend CA-AUT003 to cover all admin sign-ins rather than only admin portal access until PIM is in place.
+
+The model is intentionally lighter on routine admin work outside the admin portals application, where AdminAuth would impose FIDO2 on every admin sign-in regardless of destination. This reduces friction for organizations that have not yet completed a full FIDO2 hardware key rollout across their admin population, while still enforcing FIDO2 on the highest-risk admin surfaces.
+
+## The Agents persona business case
+
+### What Agent IDs are
+
+Microsoft Agent ID is a distinct identity class in Microsoft Entra ID. When an organization deploys a Microsoft 365 Copilot agent, an Azure AI-integrated workflow, or a custom agentic application, Entra provisions a corresponding Agent ID in the tenant. Each Agent ID operates as a non-human identity with its own authentication path and delegated permissions to Microsoft 365 resources. Agent IDs are not service principals in the traditional sense; they form a dedicated identity class with their own condition family in the Microsoft Graph Conditional Access API.
+
+### Why Agent IDs need a dedicated Conditional Access lane
+
+Agent IDs do not authenticate via the user-context flow. They cannot be included or excluded by user-targeted Conditional Access policies in the way human users can. Without an Agents-specific policy lane, Agent ID sign-ins are evaluated under the most permissive available policy for their authentication path — or not evaluated by Conditional Access at all.
+
+This gap is growing in business significance. As organizations expand their use of Copilot agents and AI-integrated workflows, the Agent ID population in the tenant grows. Each Agent ID carries delegated permissions to Microsoft 365 resources. An Agent ID with elevated permissions that is not gated by Conditional Access represents a potential lateral movement surface if an AI workflow is compromised, misconfigured, or abused.
+
+### What CA-COV011 does
+
+CA-COV011 blocks Agent ID sign-ins when Microsoft Identity Protection detects medium or high agent risk. The policy operates at the application-side filter: it targets all Agent ID service principals across all Agent ID resources, independently of user-targeted policy scope. The policy ships in report-only by default, following the same soak model as every other policy in the baseline.
+
+Operationally, CA-COV011 requires a monthly Agent ID risk-event review to ensure the Agents persona is current with the tenant's deployed agent inventory and to catch risk signals that warrant investigation. This cadence is included in the operational cost estimate in the Operational cost estimate section.
+
+### The competitive positioning point
+
+As of 2026, few community Conditional Access baselines include explicit coverage of Microsoft Agent IDs. Most frameworks were designed before the Agent ID identity class existed at scale and have not been updated to address the agentic AI identity surface. This baseline treats Agents as a first-class persona with a dedicated policy lane, a written exclusion contract (CA-EXC003), and a full design document covering the technical risk model and operational runbook (`Design/AGENTS-PERSONA-MODEL.md`). Adopters who deploy this baseline are covered on the agentic workload surface that most other published frameworks currently leave unaddressed.
+
+### Licensing dependency
+
+CA-COV011 requires Microsoft Entra ID Premium P2 for the Identity Protection signal that surfaces agent risk. It also requires that the Microsoft Agent ID feature is available in the tenant, which is the case for tenants with Microsoft 365 Copilot or Azure AI Entra integration as of May 2026.
+
+## Beta endpoint commitment
+
+The framework targets the Microsoft Graph beta endpoint for all twenty-four policies. This is a deliberate architectural decision.
+
+Three policies require the beta endpoint because Microsoft has not yet completed general availability promotion of specific features as of May 2026:
+
+- **CA-SIG003** (medium user risk) and **CA-SIG004** (medium sign-in risk) use `signInFrequency.frequencyInterval: "everyTime"` — a condition that enforces sign-in frequency on every session rather than on a fixed time interval. This parameter has not yet been promoted to the Microsoft Graph v1.0 endpoint.
+- **CA-COV011** (Agents persona) uses the Microsoft Agent ID condition family (`IncludeAgentIdServicePrincipals: ["All"]` and `IncludeApplications: ["AllAgentIdResources"]`) — condition types that exist only in the beta endpoint as of May 2026.
+
+For operational simplicity, all twenty-four policies target the beta endpoint consistently rather than maintaining a split deployment with twenty-one policies at v1.0 and three at beta. A split-endpoint deployment increases operational surface without a proportional security benefit; a single endpoint target is simpler to operate, audit, and maintain.
+
+Microsoft Graph beta is designed to be production-capable. The documented caveat is that beta features may change before GA promotion. This framework commits to publishing a v1.4 migration to the v1.0 endpoint when Microsoft completes GA promotion of `signInFrequency: everyTime` and the Agent ID condition family. Adopters should monitor the Microsoft Graph changelog and this repository for migration guidance.
+
+For executive audiences: targeting the beta endpoint is not the same as running pre-release software in production. Microsoft Graph beta is the delivery channel Microsoft uses to make real, production-deployed features available before the formal GA promotion is complete. The three beta-dependent conditions in this baseline are active in Microsoft-operated production environments today.
+
+## Licensing
+
+| Component | Required by | Note |
+|---|---|---|
+| Microsoft Entra ID P1 | All 24 policies (minimum) | Required for basic Conditional Access, device compliance integration, and named-location controls |
+| Microsoft Entra ID P2 — Identity Protection | CA-SIG003, CA-SIG004, CA-SIG005, CA-SIG008, CA-SIG009, CA-COV011 | User risk, sign-in risk, and agent risk signals; required for the risk-response policy tier |
+| Microsoft Entra ID P2 — Privileged Identity Management | Operational model (Section 4) | PIM activation enforces phishing-resistant MFA at role elevation; assumed in the AuthN strength model |
+| Microsoft Entra ID P2 — Terms of Use | CA-SIG010 | Terms of Use feature for B2B guest consent gating. The 1:5 guest-licensing ratio applies. |
+| Microsoft Entra Workload Identities Premium | CA-COV010 | Separate SKU from Entra ID P1/P2. Required for service-principal Conditional Access. |
+| Microsoft Intune | CA-COV008, CA-SIG001 | Required for `compliantDevice` grant control. Hybrid Azure AD join is an accepted alternative for both. |
+| Microsoft Agent ID feature availability | CA-COV011 | Available in tenants with Microsoft 365 Copilot or Azure AI Entra integration as of May 2026. |
+
+If P1 is already licensed for all users, the incremental cost of this baseline covers the P2 upgrade for Identity Protection, PIM, and Terms of Use; the Workload Identities Premium SKU; and Agent ID availability. For organizations with Microsoft 365 Copilot licensing already in place, Agent ID availability is typically included.
+
+If P2 is not yet in place, calculate the incremental cost against the organization's Microsoft 365 agreement:
+
+- [INSERT: CURRENT USERS AT P1 x COST-PER-USER DELTA FROM P1 TO P2]
+- [INSERT: ORGANIZATION'S ESTIMATED ANNUAL BREACH-RISK EXPOSURE]
+- [INSERT: ORGANIZATION'S CURRENT CYBER-INSURANCE PREMIUM]
+- [INSERT: INDUSTRY AVERAGE BREACH COST FROM LATEST IBM REPORT]
+
+These placeholders convert a directional business case into a quantified ROI specific to the organization. A template with named industry references ages better than one with specific dollar amounts that drift as annual reports are published.
+
+## Implementation prerequisites
+
+Before the first policy is deployed in report-only mode, the following must be in place:
+
+- **Seven persona groups** created in Entra ID and populated: `CA-Persona-EmergencyAccess`, `CA-Persona-InternalUsers`, `CA-Persona-ServiceAccounts`, `CA-Persona-GuestUsers`, `CA-Persona-WorkloadIdentities`, and the Agents persona per `Policies/CA-EXC003-Agents-Persona.md`. Membership rules and attestation owners for each group should be documented before deployment begins.
+- **Three emergency-access accounts** provisioned per `Policies/CA-EXC001-EmergencyAccess-Exclusion.md`. The sign-in alerting rule for emergency-access accounts must be configured before any policy is promoted to enforcement.
+- **Three custom authentication strengths** — StandardAuth, StrongAuth, and AdminAuth — created in the tenant from the templates in `Supporting-Artifacts/`. These must exist before the AUT-series policies can be deployed.
+- **Trusted Countries named location** created and tailored to the organization's approved operating geographies. Required before CA-COV007, CA-COV009, and CA-COV010 can be deployed.
+- **Microsoft Entra Terms of Use agreement** published and the agreement ID captured before CA-SIG010 is deployed in report-only mode. The agreement must exist before the policy can resolve the grant control.
+- **Agent ID inventory** completed per `Policies/CA-EXC003-Agents-Persona.md` before CA-COV011 is deployed. Understanding which Agent IDs exist and what permissions they hold is a prerequisite for a clean CA-COV011 report-only soak.
+- **PowerShell 7.0 or later** and the **`Microsoft.Graph.Authentication` module** installed on the deployer workstation. No other Graph SDK module is required.
+- **Intune device compliance baseline** (or hybrid Azure AD join coverage) confirmed before CA-COV008 and CA-SIG001 are promoted to enforcement. The compliant-device grant control requires a device compliance policy in Intune to signal into Conditional Access.
+
+## Operational cost estimate
+
+Annualized hours required to maintain the baseline at steady state after the phased deployment is complete:
+
+| Activity | Frequency | Hours per cycle | Annual total |
+|---|---|---|---|
+| Persona-group attestation | Quarterly | 4 hours | 16 hours |
+| Emergency-access recovery drill | Quarterly | 2 hours | 8 hours |
+| ServiceAccounts geography review | Monthly | 1 hour | 12 hours |
+| Agents persona Agent ID risk-event review | Monthly | 2 hours | 24 hours |
+| Admin-context risk review | Monthly | 1 hour | 12 hours |
+| Risk-detection tuning | Quarterly | 4 hours | 16 hours |
+| Trusted IPs named-location refresh (CI runner egress changes) | Quarterly | 4 hours where applicable | 16 hours |
+| Terms of Use version refresh and re-consent monitoring | Quarterly | 2 hours | 8 hours |
+
+**Total at steady state: approximately 112 hours per year.**
+
+This is up from the v1.2 estimate of approximately 52 hours per year. The increase is driven by three v1.3 additions:
+
+- The **Agents persona monthly risk-event review** (24 hours per year) is new. The v1.2 baseline had no Agents persona and no corresponding review cadence.
+- The **Workload Identities Trusted IPs refresh cadence** (16 hours per year) is formalized in v1.3. This operational activity existed informally in v1.2 but was not measured separately in the estimate.
+- The **Terms of Use lifecycle management** (8 hours per year) is new with CA-SIG010. Re-consent monitoring and periodic agreement version refresh are non-trivial operational activities once a Terms of Use gate is in production.
+
+For organizations with dedicated security operations, this effort can be absorbed into existing quarterly security review cadences. For smaller organizations, 112 hours represents approximately two to three days of security-architect time per quarter.
+
+## Compliance mapping
+
+This baseline supports the access control requirements in major compliance frameworks. The mapping below reflects the v1.3 policy surface. Organizations should validate specific control numbers against current framework revisions with their audit team.
+
+| Framework | Control | How this baseline supports it |
+|---|---|---|
+| SOC 2 | CC6.1 (Logical Access Controls) | CA-COV002, CA-COV008, CA-SIG001, CA-SIG008, and CA-SIG009 enforce authentication, authorization, and access restriction based on identity and context |
+| SOC 2 | CC6.6 (Boundary Protection) | CA-COV007 (BlockByLocation), CA-COV009 (ServiceAccounts trusted locations), and CA-COV010 (WorkloadIdentities trusted locations) gate access by geography and network boundary |
+| SOC 2 | CC6.7 (Privileged Access) | CA-AUT003 requires AdminAuth (FIDO2 only) on admin portals; CA-SIG005 hard-blocks admin sign-ins at medium and high risk |
+| ISO 27001 | A.5.16 (Identity management) | CA-AUT001 and CA-AUT002 enforce authentication strength at device and security info registration; CA-COV002 ensures no identity authenticates with a password alone |
+| ISO 27001 | A.5.17 (Authentication information) | The graduated strength model (StandardAuth, StrongAuth, AdminAuth) formalizes authentication quality by context and risk level |
+| HIPAA | §164.312(a)(2)(i) (Unique user identification) | CA-COV002 and CA-SIG002 enforce MFA for every identity accessing resources, supporting person-level identification assurance |
+| PCI-DSS | 8.4.2 (Strong cryptography for non-console admin) | CA-AUT003 requires FIDO2-only (AdminAuth) for admin portal sign-ins — the non-console admin surface in Microsoft 365 |
+| NIST SP 800-53 | AC-2 (Account management) | CA-AUT001 and CA-AUT002 apply authentication controls at the account provisioning moments (device enrollment and security info registration) |
+| NIST SP 800-53 | IA-2 (Identification and Authentication) | CA-COV002 combined with the graduated authentication strength model satisfies IA-2 requirements for both users and privileged users |
+
+Beyond compliance, this baseline satisfies the identity-related controls that cyber-insurance carriers increasingly require as a precondition for favorable premium pricing or coverage. MFA for all users, phishing-resistant MFA for privileged access, device compliance requirements, and risk-based access controls are among the controls carriers most frequently ask about in underwriting questionnaires.
 
 ## Recommended investment approach
 
-### Phase 1 — Foundation (week 1 to 4)
+### Phase 1 — Foundation (weeks 1 to 4)
 
-- Create persona groups (Global, Internal, Admins, Guests, ServiceAccounts) and emergency access accounts
-- Deploy Intune device compliance baseline (if not already in place)
-- Provision the three custom authentication strengths (StandardAuth, StrongAuth, AdminAuth)
-- Provision the Trusted Countries named location with the organization's operating geographies
-- Import all twenty-three policies in report-only mode
-- Begin MFA registration campaign
+Create the seven persona groups and populate them per the membership rules in `Design/POLICY-DESIGN.md` Section 3. Provision three emergency-access accounts and configure the sign-in alerting rule per `Policies/CA-EXC001-EmergencyAccess-Exclusion.md`. Create the three custom authentication strengths (StandardAuth, StrongAuth, AdminAuth) from the templates in `Supporting-Artifacts/`. Create the Trusted Countries named location and tailor it to the organization's approved operating geographies. Publish the Microsoft Entra Terms of Use agreement and capture the agreement ID for CA-SIG010. Run the Agent ID inventory per `Policies/CA-EXC003-Agents-Persona.md` before adopting the Agents persona.
 
-### Phase 2 — Soak and validation (weeks 5 to 8)
+### Phase 2 — Coverage (weeks 5 to 8)
 
-- Monitor report-only results for each policy
-- Remediate any findings (users without MFA, services using legacy auth, non-compliant devices, service accounts authenticating from unregistered IPs)
-- Complete phishing-resistant method rollout to privileged users
-- Inventory Token Protection client compatibility (Windows build, modern auth confirmed)
+Deploy CA-COV001 through CA-COV007 plus CA-AUT001 and CA-AUT002 in report-only mode. Soak each policy for a minimum of seven to fourteen days. Remediate findings: users without MFA, services using legacy auth, service accounts authenticating from unregistered geographies. Begin the MFA registration campaign for the full user population. Promote Phase 2 policies to enforcement after the soak window closes clean.
 
-### Phase 3 — Staged enforcement (weeks 9 to 14)
+### Phase 3 — Persona-specific (weeks 9 to 12)
 
-- Promote policies from report-only to enforced in the sequence defined in POLICY-DESIGN.md section 5
-- Monitor helpdesk and Entra sign-in logs for friction
-- Declare baseline v1.2 complete
+Deploy persona-specific policies in report-only mode: Internal persona (CA-COV008, CA-SIG007), Admins persona (CA-AUT003, CA-SIG005), Guests persona (CA-SIG002, CA-SIG006, CA-SIG010), ServiceAccounts persona (CA-COV009), WorkloadIdentities persona (CA-COV010), and Agents persona (CA-COV011). Inventory Token Protection client compatibility — Windows build and modern auth confirmed — before the CA-SIG007 soak. Complete the phishing-resistant method rollout to privileged users before CA-AUT003 enforcement. Soak each policy for a minimum of seven to fourteen days.
 
-### Phase 4 — Steady state (ongoing)
+### Phase 4 — Risk and Token Protection (weeks 13 to 16)
 
-- Quarterly review per the cadence defined above
-- Extend the baseline with additional frameworks (Intune Compliance Baseline, Entra ID Governance Toolkit, Defender XDR Detection Rules) from this same repository
+Deploy the risk policies — CA-SIG003, CA-SIG004, CA-SIG008, CA-SIG009 — and the Sensitive-Applications scope policy CA-SIG001, all in report-only mode. Layer Token Protection per `Design/CAE-TOKEN-PROTECTION-LAYERING.md`. Use `Scripts/Get-CABaselineImpact.ps1` to quantify what each risk policy would have blocked over the soak period. Soak for a minimum of fourteen days before promoting risk policies to enforcement; a longer soak is recommended for CA-SIG008 and CA-SIG009 (the high-risk hard-blocks) to confirm false-positive rates are acceptable.
 
-## The investment recommendation
+### Phase 5 — Enforcement promotion (weeks 17 to 20)
 
-Adopt this Conditional Access baseline as the identity security floor for the organization. The incremental cost is modest when P1 is already licensed, the operational burden is measured in a few dozen hours per year, and the risk reduction addresses the single most common initial-access vector in contemporary breach data.
+Promote all remaining report-only policies to enforcement on the documented soak-completion schedule. Pair with the Intune Compliance Baseline rollout per `Design/CA-ICB-INTEGRATION.md` to ensure that the compliant-device signal that CA-COV008 and CA-SIG001 depend on is clean before enforcement decisions are made. Establish the quarterly review cadence described in the Operational cost estimate section. Declare the v1.3 baseline deployment complete.
 
-Conditional Access is Microsoft's Zero Trust policy engine. Deploying a defensible baseline is a decision that can be audited, defended, and amended. Choosing to defer it is also a decision, and one that should be made with full awareness of the risk being accepted.
+Total: a twenty-week phased rollout. Up from the v1.2 estimate of twelve weeks. The extension is driven by the Agents persona soak and Agent ID inventory, the Workload Identities Trusted IPs initial setup and SPN scoping exercise, and the additional enforcement-promotion phase the larger v1.3 surface requires.
 
 ## References
 
@@ -209,15 +271,19 @@ Conditional Access is Microsoft's Zero Trust policy engine. Deploying a defensib
 - IBM Security. *Cost of a Data Breach Report* (annual).
 - Microsoft. *Microsoft Digital Defense Report* (annual).
 - Microsoft Learn. [Conditional Access architecture](https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-policies).
+- Microsoft Learn. [Authentication strengths](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths).
+- Microsoft Learn. [Continuous Access Evaluation](https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-continuous-access-evaluation).
+- Microsoft Learn. [Token Protection](https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-token-protection).
+- Microsoft Learn. [Conditional Access API reference (beta)](https://learn.microsoft.com/en-us/graph/api/resources/conditionalaccesspolicy?view=graph-rest-beta).
 - Cloud Harbor Consulting. [Why Entra ID Conditional Access Fails in Practice (And How to Fix It)](https://www.cloudharborconsulting.cloud/post/why-entra-id-conditional-access-fails-in-practice-and-how-to-fix-it).
+- Cloud Harbor Consulting. `Design/POLICY-DESIGN.md` — full per-policy design specifications, exclusion rationale, and rollout sequence.
+- Cloud Harbor Consulting. `Design/AGENTS-PERSONA-MODEL.md` — Microsoft Agent ID technical overview, risk signal model, CA-COV011 mechanics, and beta endpoint commitment.
+- Cloud Harbor Consulting. `Design/CAE-TOKEN-PROTECTION-LAYERING.md` — Continuous Access Evaluation and Token Protection layering analysis, client matrix, and soak procedure.
+- Cloud Harbor Consulting. `Design/WORKLOAD-IDENTITY-IP-PATTERNS.md` — workload identity IP allow-listing patterns, CI/CD runner egress management, and rollback procedure.
+- Cloud Harbor Consulting. `Design/CA-ICB-INTEGRATION.md` — Conditional Access and Intune Compliance Baseline cross-framework integration: signal flow, failure-mode matrix, and rollout sequence.
 
-## Notes on bracketed placeholders
+## Acknowledgments
 
-Three bracketed placeholders in this document should be populated by the deploying organization before this business case is presented to executive leadership:
+This framework was shaped by the public work of Joey Verlinden, Daniel Chronlund, and Claus Jespersen on Conditional Access design patterns. Their published guidance on persona-based scoping, exclusion contract governance, and authentication strength selection provided the conceptual foundation for this baseline.
 
-- Estimated annual breach-risk exposure (from the organization's risk register or cyber-insurance questionnaire)
-- Current cyber-insurance premium (from the organization's insurance renewal data)
-- Industry average breach cost (from the most recent IBM *Cost of a Data Breach Report*)
-- Incremental P1-to-P2 licensing cost per user (from the organization's Microsoft licensing agreement)
-
-These numbers convert a directional business case into a quantified ROI specific to the organization. A template with named industry references ages better than a template with specific percentages that drift as new reports are published.
+The v1.3 redirection — including the Agents persona introduction, the all-beta endpoint commitment, the graduated authentication strength enforcement model, and the four new design documents — was developed by the Cloud Harbor Consulting team.

--- a/Frameworks/Conditional-Access-Baseline/README.md
+++ b/Frameworks/Conditional-Access-Baseline/README.md
@@ -2,7 +2,7 @@
 
 A defensible-baseline framework for Microsoft Entra ID Conditional Access. Twenty-four policies covering eight identity personas, scoped to the access paths attackers exploit most frequently, with every policy shipped in report-only by default so adopters validate impact before enforcement. Companion reading: [Why Entra ID Conditional Access Fails in Practice (And How to Fix It)](https://www.cloudharborconsulting.cloud/post/why-entra-id-conditional-access-fails-in-practice-and-how-to-fix-it).
 
-**Status:** Preview — v1.3.0-rc.1
+**Status:** 🟢 Released — v1.3.0
 
 > **Beta endpoint:** This framework targets `https://graph.microsoft.com/beta/identity/conditionalAccess/policies` for all 24 policies. Three policies use Microsoft Graph beta-only features as of May 2026 (`CA-SIG003` and `CA-SIG004` use `signInFrequency.frequencyInterval: "everyTime"`; `CA-COV011` uses the Microsoft Agent ID condition family). See the Prerequisites section and `Design/AGENTS-PERSONA-MODEL.md` for the GA promotion tracking commitment.
 
@@ -229,9 +229,9 @@ Per-policy design specs (intent, principle mapping, scope, conditions, controls,
 - [x] ROI-CONDITIONAL-ACCESS.md v1.2 rollup
 - [x] CAE and Token Protection layering note (CA-SIG007 paired design doc)
 
-### v1.3 — Released (this PR)
+### v1.3 — Shipped (2026-05-28)
 
-- [x] 23-policy baseline sourced from prod tenant restructure
+- [x] 24-policy baseline sourced from prod tenant restructure
 - [x] All-beta endpoint architecture (`Microsoft.Graph.Authentication` only, `Invoke-MgGraphRequest` deployer)
 - [x] Agents persona as first-class identity class (CA-EXC003, CA-COV011, AGENTS-PERSONA-MODEL.md)
 - [x] CA-COV010 WorkloadIdentities-TrustedLocations retained and renumbered from CA-COV003
@@ -242,10 +242,14 @@ Per-policy design specs (intent, principle mapping, scope, conditions, controls,
 - [x] CAE and Token Protection layering deep-dive design doc (Design/CAE-TOKEN-PROTECTION-LAYERING.md) — threat model, signal models, client matrix, replay-resistance trade-offs, layering order, 14-day soak procedure
 - [x] Workload identity IP allow-listing patterns and CI/CD examples (Design/WORKLOAD-IDENTITY-IP-PATTERNS.md) — SPN per-pipeline scoping, Trusted IPs refresh cadence per runner class, rollback procedure, GitHub Actions and Azure DevOps examples
 - [x] CA-ICB cross-framework integration doc (Design/CA-ICB-INTEGRATION.md) — signal flow narrative with Mermaid diagram, per-policy ICB requirements for CA-COV008, CA-SIG001, and CA-SIG007, failure-mode matrix, CA-to-ICB rollout sequence, 5-test verification procedure, and out-of-scope disclosure
+- [x] ROI-CONDITIONAL-ACCESS.md v1.3 wholesale rewrite; CHANGELOG v1.3.0 promotion; root README and framework README sync (this PR)
 
-### v1.4 — Candidates
+### v1.4 — Candidates (not committed)
 
-- [ ] Release prep (ROI v1.3 rewrite, CHANGELOG v1.3.0 entry, root README sync, v1.3.0 tag) — PR 6
+- [ ] Microsoft Agent ID v1.0 schema migration once Microsoft completes GA promotion of the Agent ID condition family
+- [ ] `signInFrequency: everyTime` v1.0 migration once Microsoft promotes `frequencyInterval: "everyTime"` to the v1.0 endpoint
+- [ ] Mobile platform Token Protection coverage once Microsoft ships support for iOS and Android token binding
+- [ ] Named-location refresh utility script in Scripts/ if adopter demand warrants
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Every framework in this repo includes:
 
 | Framework | Status | Latest | Notes |
 |-----------|--------|--------|-------|
-| [Conditional Access Baseline](./Frameworks/Conditional-Access-Baseline/) | Released | v1.2.0 (2026-05-15) | 23 policies across 5 personas plus workload identities; report-only by default |
+| [Conditional Access Baseline](./Frameworks/Conditional-Access-Baseline/) | Released | v1.3.0 (2026-05-28) | 24 policies across 7 personas plus workload identities and Sensitive-Apps scope; new Agents persona for AI/Copilot agents; all-beta endpoint; report-only by default |
 | [Intune Compliance Baseline](./Frameworks/Intune-Compliance-Baseline/) | Preview | v0.1.0-preview (2026-05-15) | First Windows 10/11 compliance template + framework design spec; macOS, iOS, Android, Linux templates and Deploy-ICBaseline.ps1 land toward Q3 2026 full-framework completion |
 | [Security Reporting Decision Rubric](./Frameworks/Security-Reporting-Decision-Rubric/) | Preview | v0.1.0-preview (pending) | 4-question decision flow for designing audience-scoped security reports; severity floor guidance grounded in Defender XDR's severity model; 2 starter templates (board quarterly, CISO monthly) |
 | Entra ID Governance Toolkit | Planned | — | First Access Reviews automation templates Month 2 Week 2 (May 2026); full framework Q4 2026 |


### PR DESCRIPTION
## Summary

Closes the v1.3 release cycle for the Conditional Access Baseline framework. Wholesale rewrite of the executive ROI document for the 24-policy v1.3 surface with new Agents persona business case and AuthN strength enforcement-model sections. Promotes all `[Unreleased]` CHANGELOG content from PRs 1 through 5 plus prior Unreleased work into a `[1.3.0] - 2026-05-28` release section. Root README Frameworks table synced. Framework README status banner flipped to Released v1.3.0 with the Roadmap section restructured (v1.3 candidates Shipped, v1.4 candidates seeded).

## Design principle citation

This release closes 4 v1.3 candidates committed in the v1.2 release roadmap plus the stack adoption work that defines v1.3's surface. All four defensible-baseline principles preserved: identity-wide coverage extended to Agents (a new identity class); no standing exclusions (EmergencyAccess and ServiceAccounts remain the only permanent excludes with Agents managed via a positive-targeting persona contract); layered signals (risk policies now combine StrongAuth, riskRemediation, and SignInFrequency everyTime for tighter graduated response); tightened Authentication Strengths (AdminAuth on admin portals, StrongAuth on risk, StandardAuth on user actions).

## Changes

- Frameworks/Conditional-Access-Baseline/Business-Case/ROI-CONDITIONAL-ACCESS.md: wholesale rewrite. 13 sections. New Agents persona business case. New AuthN strength enforcement-model section. New beta-endpoint commitment section. Operational hours estimate updated from ~52 to ~112 per year. Phased investment approach extended from 12 to 20 weeks.
- CHANGELOG.md: `[Unreleased]` promoted to `[1.3.0] - 2026-05-28`. New release narrative paragraph. Compare-link footer chain extended.
- README.md (root): Frameworks table CA row updated to v1.3.0.
- Frameworks/Conditional-Access-Baseline/README.md: status banner Released v1.3.0. Roadmap section restructured (v1.3 Shipped, v1.4 candidates seeded).

## What ships under v1.3.0

- 24 starter policies across 7 personas plus Sensitive-Applications scope.
- Microsoft Agent ID persona as a first-class identity class.
- 3 written exclusion contracts (CA-EXC001 EmergencyAccess, CA-EXC002 ServiceAccounts, CA-EXC003 Agents).
- 4 new design docs (AGENTS-PERSONA-MODEL, CAE-TOKEN-PROTECTION-LAYERING, WORKLOAD-IDENTITY-IP-PATTERNS, CA-ICB-INTEGRATION).
- Microsoft Graph beta endpoint commitment.
- camelCase REST API wire format JSON.

## What goes out as v1.4 candidates (not committed)

- Microsoft Agent ID v1.0 schema migration once Microsoft completes GA promotion.
- `signInFrequency: everyTime` v1.0 migration once Microsoft promotes.
- Mobile platform Token Protection coverage once Microsoft ships support.
- Named-location refresh utility script in Scripts/ if adopter demand warrants.
