### PR TITLE
Add EIG-AR001 quarterly guest access review automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Entra ID Governance Toolkit framework skeleton at `Frameworks/Entra-ID-Governance-Toolkit/`. Replaces the stub README with a framework landing page covering scope (Access Reviews now, Lifecycle Workflows and PIM governance as the v1.0 target), the EIG-AR / EIG-LW / EIG-PIM naming convention, the planned scripts inventory, the self-invoking deployment model, and Entra ID P2 prerequisites. No scripts and no tag in this change.
 - Entra ID Governance Toolkit: policy design specification (Design/POLICY-DESIGN.md) defining the 4 framework principles, the EIG naming convention, the persona model, the rollout sequence, and the per-script design specs for EIG-AR001 and EIG-AR002.
+- Frameworks/Entra-ID-Governance-Toolkit/Scripts/EIG-AR001-QuarterlyGuestAccessReview.ps1 and its paired contract EIG-AR001-QuarterlyGuestAccessReview.md: first Access Reviews automation for the Entra ID Governance Toolkit. Creates a recurring quarterly access review over B2B guest membership across all Microsoft 365 groups, with deny-by-default decisions, auto-applied removal of denied guests, and a named fallback reviewer. Implements design spec section 7.1. The sponsor reviewer query ships as a confirm-in-tenant placeholder.
 
 ---
 

--- a/Frameworks/Entra-ID-Governance-Toolkit/Scripts/EIG-AR001-QuarterlyGuestAccessReview.md
+++ b/Frameworks/Entra-ID-Governance-Toolkit/Scripts/EIG-AR001-QuarterlyGuestAccessReview.md
@@ -1,0 +1,90 @@
+# EIG-AR001 Quarterly Guest Access Review
+
+Paired contract for `EIG-AR001-QuarterlyGuestAccessReview.ps1`. This document is
+the plain-language description of what the script configures and the commitments
+the control makes. It is reviewed against design spec section 7.1.
+
+## What it does
+
+Creates a recurring quarterly Microsoft Entra access review covering B2B guest
+user membership across all Microsoft 365 groups. The review recurs on a fixed
+quarterly cadence defined in the review definition, so the control does not
+depend on anyone remembering to run it.
+
+## Scope
+
+- Reviewed population: guest users (`userType eq 'Guest'`) who are members of
+  Microsoft 365 (Unified) groups.
+- Enumeration scope: all Microsoft 365 groups in the tenant.
+
+## Recurrence
+
+Quarterly. The recurrence pattern is `absoluteMonthly` with an interval of 3,
+starting on the configured start date and continuing with no end date.
+
+## Reviewer model
+
+The primary reviewer is the guest sponsor where a sponsor is recorded on the
+guest account. Where no sponsor is recorded, a named fallback team reviews the
+guest.
+
+CONFIRM-IN-TENANT: the exact reviewer query for guest sponsors was not verified
+against a live tenant for this preview release. The sponsor reviewer query in
+the script ships as a `REPLACE_WITH_VERIFIED_SPONSOR_REVIEWER_QUERY` placeholder.
+Validate the sponsor reviewer query in your own tenant, then replace the
+placeholder before running. The fallback reviewer block is verified and ready;
+supply the fallback team object ID through the `FallbackReviewerId` parameter.
+The script refuses to run while either placeholder is unresolved.
+
+## Decision policy
+
+Decisions default to Deny. If a reviewer does not respond before the review
+closes, the guest is denied by default. There is no silent auto-approve.
+
+## Post-review action
+
+Decisions are auto-applied. A guest who is denied is removed from the reviewed
+group.
+
+## Evidence retention
+
+Review decisions and reviewer identity are retained for the audit retention
+period so an auditor can reconstruct who reviewed what, when, and with what
+outcome.
+
+## Required Graph permission scopes
+
+- AccessReview.ReadWrite.All
+- AccessReview.ReadWrite.Membership
+
+## Prerequisites
+
+- Entra ID P2 licensing.
+- PowerShell 7.
+- The Microsoft.Graph.Authentication module.
+- The operator consents to the required scopes before the script is run.
+
+## How to run
+
+1. Resolve the placeholders. Set `FallbackReviewerId` to the object ID of the
+   fallback reviewer team, and replace the sponsor reviewer query placeholder
+   with the verified query for your tenant.
+2. Preview without writing:
+
+       ./EIG-AR001-QuarterlyGuestAccessReview.ps1 -FallbackReviewerId <object-id> -WhatIf
+
+3. Create the review definition:
+
+       ./EIG-AR001-QuarterlyGuestAccessReview.ps1 -FallbackReviewerId <object-id>
+
+4. Confirm in the Entra admin center that the review definition was created with
+   the expected quarterly recurrence and reviewer assignment.
+
+## Parameters
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
+| FallbackReviewerId | REPLACE_WITH_FALLBACK_REVIEWERS_GROUP_OBJECT_ID | Object ID of the named fallback reviewer team |
+| StartDate | today | First occurrence date in yyyy-MM-dd form |
+| InstanceDurationInDays | 25 | Days each review instance stays open |
+| DisplayName | EIG-AR001 Quarterly Guest Access Review | Display name for the review definition |

--- a/Frameworks/Entra-ID-Governance-Toolkit/Scripts/EIG-AR001-QuarterlyGuestAccessReview.ps1
+++ b/Frameworks/Entra-ID-Governance-Toolkit/Scripts/EIG-AR001-QuarterlyGuestAccessReview.ps1
@@ -1,0 +1,163 @@
+#Requires -Version 7.0
+#Requires -Modules Microsoft.Graph.Authentication
+
+<#
+.SYNOPSIS
+    EIG-AR001. Stands up the quarterly Access Review over B2B guest accounts.
+
+.DESCRIPTION
+    Creates a recurring quarterly Microsoft Entra access review covering guest
+    user membership across all Microsoft 365 groups. Decisions default to Deny
+    when a reviewer does not respond before the review closes, decisions are
+    auto-applied, and a denied guest is removed from the reviewed group. The
+    recurrence and reviewer assignment live in the review definition so the
+    control recurs without an operator remembering to run it.
+
+    Part of the Entra ID Governance Toolkit. Self-invoking. No unified deployer
+    at v0.1.0-preview.
+
+.PARAMETER FallbackReviewerId
+    Object ID of the named fallback reviewer team that reviews guests with no
+    recorded sponsor. Replace the REPLACE_WITH placeholder before running.
+
+.PARAMETER StartDate
+    First occurrence date in yyyy-MM-dd form. Defaults to today.
+
+.PARAMETER InstanceDurationInDays
+    Number of days each review instance stays open. Defaults to 25.
+
+.PARAMETER DisplayName
+    Display name for the review definition.
+
+.NOTES
+    EIG-AR001-QuarterlyGuestAccessReview
+    Paired contract: EIG-AR001-QuarterlyGuestAccessReview.md
+    Graph surface : POST /identityGovernance/accessReviews/definitions (v1.0)
+    Required scopes: AccessReview.ReadWrite.All, AccessReview.ReadWrite.Membership
+    Prerequisites : Entra ID P2, PowerShell 7, Microsoft.Graph.Authentication
+#>
+
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+param(
+    [Parameter()]
+    [string]$FallbackReviewerId = 'REPLACE_WITH_FALLBACK_REVIEWERS_GROUP_OBJECT_ID',
+
+    [Parameter()]
+    [string]$StartDate = (Get-Date).ToString('yyyy-MM-dd'),
+
+    [Parameter()]
+    [ValidateRange(1, 30)]
+    [int]$InstanceDurationInDays = 25,
+
+    [Parameter()]
+    [string]$DisplayName = 'EIG-AR001 Quarterly Guest Access Review'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Status {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Message,
+
+        [Parameter()]
+        [ValidateSet('Info', 'Success', 'Warning')]
+        [string]$Level = 'Info'
+    )
+    $prefix = switch ($Level) {
+        'Success' { '[ OK ]' }
+        'Warning' { '[WARN]' }
+        default   { '[INFO]' }
+    }
+    Write-Host "$prefix $Message"
+}
+
+# Sponsor-first reviewer model.
+# Design spec EIG-AR001 assigns the guest sponsor as the primary reviewer, with
+# the named fallback team reviewing guests that have no recorded sponsor.
+#
+# CONFIRM-IN-TENANT: the exact accessReviewReviewerScope query for guest
+# sponsors was not verified against a live tenant for this preview. Validate the
+# sponsor reviewer query in your own tenant, then replace the placeholder below.
+# The fallback reviewers block is verified and ready. See the paired contract
+# EIG-AR001-QuarterlyGuestAccessReview.md, section "Reviewer model".
+$reviewers = @(
+    @{
+        query     = 'REPLACE_WITH_VERIFIED_SPONSOR_REVIEWER_QUERY'
+        queryType = 'MicrosoftGraph'
+    }
+)
+
+$fallbackReviewers = @(
+    @{
+        query     = "/groups/$FallbackReviewerId"
+        queryType = 'MicrosoftGraph'
+    }
+)
+
+# Refuse to run while REPLACE_WITH placeholders are unresolved.
+$unresolved = [System.Collections.Generic.List[string]]::new()
+if ($FallbackReviewerId -like 'REPLACE_WITH_*') { $unresolved.Add('FallbackReviewerId') }
+if ($reviewers[0].query -like 'REPLACE_WITH_*') { $unresolved.Add('sponsor reviewer query') }
+if ($unresolved.Count -gt 0) {
+    throw "Unresolved placeholders: $($unresolved -join ', '). Resolve them before running. See EIG-AR001-QuarterlyGuestAccessReview.md."
+}
+
+$requiredScopes = @('AccessReview.ReadWrite.All', 'AccessReview.ReadWrite.Membership')
+if (-not (Get-MgContext)) {
+    Write-Status "Connecting to Microsoft Graph with scopes: $($requiredScopes -join ', ')."
+    Connect-MgGraph -Scopes $requiredScopes | Out-Null
+}
+
+$definition = @{
+    displayName             = $DisplayName
+    descriptionForAdmins    = 'Quarterly access review of B2B guest membership across all Microsoft 365 groups. Denies access when the reviewer does not respond before the review closes and removes the denied guest from the reviewed group.'
+    descriptionForReviewers = 'Confirm whether each guest still needs access to this group. If you do not respond before the review closes, access is denied by default and the guest is removed from the group.'
+    scope = @{
+        '@odata.type' = '#microsoft.graph.accessReviewQueryScope'
+        query         = './members/microsoft.graph.user/?$count=true&$filter=(userType eq ''Guest'')'
+        queryType     = 'MicrosoftGraph'
+    }
+    instanceEnumerationScope = @{
+        '@odata.type' = '#microsoft.graph.accessReviewQueryScope'
+        query         = '/groups?$filter=(groupTypes/any(c:c eq ''Unified''))'
+        queryType     = 'MicrosoftGraph'
+    }
+    reviewers         = $reviewers
+    fallbackReviewers = $fallbackReviewers
+    settings = @{
+        mailNotificationsEnabled        = $true
+        reminderNotificationsEnabled    = $true
+        justificationRequiredOnApproval = $true
+        defaultDecisionEnabled          = $true
+        defaultDecision                 = 'Deny'
+        instanceDurationInDays          = $InstanceDurationInDays
+        autoApplyDecisionsEnabled       = $true
+        recommendationsEnabled          = $true
+        recurrence = @{
+            pattern = @{
+                type       = 'absoluteMonthly'
+                interval   = 3
+                dayOfMonth = 1
+            }
+            range = @{
+                type      = 'noEnd'
+                startDate = $StartDate
+            }
+        }
+    }
+}
+
+$uri = 'https://graph.microsoft.com/v1.0/identityGovernance/accessReviews/definitions'
+
+if ($PSCmdlet.ShouldProcess($DisplayName, 'Create quarterly guest access review definition')) {
+    $body = $definition | ConvertTo-Json -Depth 12
+    $response = Invoke-MgGraphRequest -Method POST -Uri $uri -Body $body -ContentType 'application/json'
+    Write-Status "Created access review definition '$($response.displayName)' with id $($response.id)." -Level Success
+    Write-Status 'Confirm in the Entra admin center that the recurrence and reviewer assignment match the design.'
+}
+else {
+    Write-Status 'WhatIf: no access review definition was created.' -Level Warning
+}


### PR DESCRIPTION
## Summary
Adds EIG-AR001, the first Access Reviews automation script in the Entra ID Governance Toolkit, plus its paired contract. Implements design spec section 7.1.

The script creates a recurring quarterly Microsoft Entra access review over B2B guest membership across all Microsoft 365 groups. Decisions default to Deny when a reviewer does not respond, decisions are auto-applied, and a denied guest is removed from the reviewed group. Recurrence and reviewer assignment live in the review definition.

This PR creates the Scripts/ folder for the framework.

## Reviewer model
Primary reviewer is the guest sponsor, with a named fallback team where no sponsor is recorded. The sponsor reviewer query ships as a confirm-in-tenant placeholder; the fallback reviewer block is ready. The script refuses to run while either placeholder is unresolved.

## Scopes
AccessReview.ReadWrite.All and AccessReview.ReadWrite.Membership.

## Files
- Frameworks/Entra-ID-Governance-Toolkit/Scripts/EIG-AR001-QuarterlyGuestAccessReview.ps1
- Frameworks/Entra-ID-Governance-Toolkit/Scripts/EIG-AR001-QuarterlyGuestAccessReview.md
- CHANGELOG.md [Unreleased] Added entry
