### PR TITLE
Verify Agent ID CA field set against Microsoft Graph beta reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Verified the Agent ID Conditional Access field set against the Microsoft Graph beta reference (2026-06-03 refresh); reaffirmed the beta-endpoint commitment and flagged the unpublished AllAgentIdResources and includeAgentIdServicePrincipals All tokens as confirm-in-tenant.
+
 ---
 
 ## [eig-v0.1.0-preview] - 2026-06-05

--- a/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
@@ -150,19 +150,28 @@ After the 14-day soak, if the report-only output shows:
 
 ## 6. Beta endpoint commitment
 
-As of May 2026, all Agent ID condition fields used in CA-COV011 are Microsoft Graph beta-only:
+Every agent-specific Conditional Access field is Microsoft Graph beta-only. None is present on the v1.0 endpoint, and each is labelled Preview in the Entra admin center portal. The table below records the verified field set as of the 2026-06-03 Conditional Access for Agents documentation refresh, confirmed against the Microsoft Graph `conditionalAccessConditionSet` and `conditionalAccessClientApplications` reference pages.
 
-| Field | Status | Source |
-|---|---|---|
-| `conditions.agentIdRiskLevels` | Beta only | Microsoft Learn v1.0 conditionalAccessConditionSet refresh dated 12/02/2025 |
-| `conditions.clientApplications.includeAgentIdServicePrincipals` | Beta only | Same source |
-| `conditions.applications.includeApplications: ["AllAgentIdResources"]` | Beta only | Same source |
+| Agent field | JSON property | Beta-only | Portal Preview | Source |
+|---|---|---|---|---|
+| Agent identity risk level condition | `conditionalAccessConditionSet.agentIdRiskLevels` | Yes | Yes | <https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id> and the Microsoft Graph `conditionalAccessConditionSet` reference |
+| Include agent identity service principals | `conditionalAccessClientApplications.includeAgentIdServicePrincipals` | Yes | Yes | <https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-autonomous-agents> and the Microsoft Graph `conditionalAccessClientApplications` reference |
+| Exclude agent identity service principals | `conditionalAccessClientApplications.excludeAgentIdServicePrincipals` | Yes | Yes | Microsoft Graph `conditionalAccessClientApplications` reference |
+| Agent identity service principal filter | `conditionalAccessClientApplications.agentIdServicePrincipalFilter` | Yes | Yes | Microsoft Graph `conditionalAccessClientApplications` reference |
 
-The baseline framework targets the beta endpoint (`https://graph.microsoft.com/beta/identity/conditionalAccess/policies`) for all 23 policies to avoid conditional endpoint logic in the deployer. Splitting the policy set between v1.0 and beta endpoints would require maintaining two deployer code paths, two sets of test fixtures, and runtime logic to decide which endpoint applies to which policy.
+`agentIdRiskLevels` is the correct property name (it is not `agentRiskLevels`). It is multivalued and accepts `low`, `medium`, `high`, and `unknownFutureValue`. The v1.0 `conditionalAccessConditionSet` has no agent-risk property at all. Microsoft recommends `agentIdRiskLevels = high` for agent-identity policies, and `medium` and `high` for agent-user policies.
 
-**GA promotion tracking:** When Microsoft promotes `agentIdRiskLevels`, `includeAgentIdServicePrincipals`, and `AllAgentIdResources` to the v1.0 Graph API, this framework will flip the deployer endpoint to v1.0 as a single change. That change will be documented in the CHANGELOG and will not require updates to any policy JSON template — the conditions use the same field names in both beta and v1.0.
+**Not yet published in the Graph reference (confirm-in-tenant pending GA):** the following are referenced in the Conditional Access for Agents documentation but are not yet typed in the Microsoft Graph reference, so this framework ships them as confirm-in-tenant values that an adopter must validate against the live tenant before enforcement:
 
-Watch the Microsoft Graph Conditional Access API changelog for the GA promotion announcement. The Microsoft Learn conditional access API reference page for `conditionalAccessConditionSet` is the authoritative source.
+- The `AllAgentIdResources` application bundle. The repo currently uses `includeApplications: ["AllAgentIdResources"]`, but the bundle is not published in the Graph reference.
+- The `"All"` literal for `includeAgentIdServicePrincipals`. The reference types this property as a collection of agent identity object IDs and documents no `"All"` literal.
+- Agent identity blueprint targeting, agent user account targeting, and the Agent execution environments condition property.
+
+The baseline framework targets the beta endpoint (`https://graph.microsoft.com/beta/identity/conditionalAccess/policies`) for all 24 policies to avoid conditional endpoint logic in the deployer. Splitting the policy set between v1.0 and beta endpoints would require maintaining two deployer code paths, two sets of test fixtures, and runtime logic to decide which endpoint applies to which policy.
+
+**GA promotion tracking:** When Microsoft promotes the agent fields above to the v1.0 Graph API, this framework will flip the deployer endpoint to v1.0 as a single change. That change will be documented in the CHANGELOG and will not require updates to any policy JSON template, because the conditions use the same field names in both beta and v1.0. The unpublished `AllAgentIdResources` bundle and `includeAgentIdServicePrincipals` `"All"` token will be reconciled against the published reference at that time.
+
+Watch the Microsoft Graph Conditional Access API changelog for the GA promotion announcement. The Microsoft Graph `conditionalAccessConditionSet` and `conditionalAccessClientApplications` reference pages are the authoritative sources, alongside <https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id> and <https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-autonomous-agents>.
 
 ---
 

--- a/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
@@ -40,12 +40,12 @@ The v1.3 slate makes the following changes relative to prior Unreleased state. T
 
 #### Beta endpoint commitment
 
-All 24 policies in this baseline target `https://graph.microsoft.com/beta/identity/conditionalAccess/policies`. Three policies use features that are Microsoft Graph beta-only as of May 2026:
+All 24 policies in this baseline target `https://graph.microsoft.com/beta/identity/conditionalAccess/policies`. Three policies use features that are Microsoft Graph beta-only:
 
 - `CA-SIG003-Global-MediumUserRisk` and `CA-SIG004-Global-MediumSignInRisk` use `signInFrequency.frequencyInterval: "everyTime"`, which is not available in the v1.0 endpoint.
-- `CA-COV011-Agents-BlockMediumAndHighRisk` uses `agentIdRiskLevels`, `IncludeAgentIdServicePrincipals`, and `AllAgentIdResources`, all of which are beta-only.
+- `CA-COV011-Agents-BlockMediumAndHighRisk` uses the agent-specific fields. As of the 2026-06-03 Conditional Access for Agents documentation refresh, every agent-specific field is beta-only (absent from the v1.0 endpoint) and labelled Preview in the portal. The condition-set property `agentIdRiskLevels` (not `agentRiskLevels`) and the client-application properties `includeAgentIdServicePrincipals`, `excludeAgentIdServicePrincipals`, and `agentIdServicePrincipalFilter` are verified against the Microsoft Graph `conditionalAccessConditionSet` and `conditionalAccessClientApplications` reference pages. The `AllAgentIdResources` application bundle and the `includeAgentIdServicePrincipals` `"All"` token are not yet published in the Graph reference and ship as confirm-in-tenant pending GA.
 
-Rather than maintain two endpoint paths, the framework commits all 24 policies to the beta endpoint. When Microsoft completes GA promotion of these fields, the endpoint URL can be flipped in one deployer change without updating any policy template. See `Design/AGENTS-PERSONA-MODEL.md` section 6 for the GA tracking commitment.
+Rather than maintain two endpoint paths, the framework commits all 24 policies to the beta endpoint. When Microsoft completes GA promotion of these fields, the endpoint URL can be flipped in one deployer change without updating any policy template. See `Design/AGENTS-PERSONA-MODEL.md` section 6 for the verified field-status table and the GA tracking commitment.
 
 #### Agents persona as first-class identity class
 


### PR DESCRIPTION
Reaffirm the beta-endpoint commitment for the Agents persona against the 2026-06-03 Conditional Access for Agents documentation refresh. Replace the field-status table in AGENTS-PERSONA-MODEL.md with a verified table dated 2026-06-03 covering agentIdRiskLevels, includeAgentIdServicePrincipals, excludeAgentIdServicePrincipals, and agentIdServicePrincipalFilter, each beta-only and portal-labelled Preview, with source URLs. Flag the unpublished AllAgentIdResources bundle and the includeAgentIdServicePrincipals "All" token as confirm-in-tenant pending GA, and update POLICY-DESIGN.md to match. No policy JSON changes.
