### PR TITLE
Correct Agents persona licensing, prerequisites, and admin roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Verified the Agent ID Conditional Access field set against the Microsoft Graph beta reference (2026-06-03 refresh); reaffirmed the beta-endpoint commitment and flagged the unpublished AllAgentIdResources and includeAgentIdServicePrincipals All tokens as confirm-in-tenant.
 
+### Fixed
+
+- Corrected the Agents persona licensing to Microsoft Entra ID P1 or P2 plus a Microsoft Agent 365 license per user, added Microsoft Entra Internet Access for agent network controls, and documented the Conditional Access Administrator and Attribute Assignment Reader roles.
+
 ---
 
 ## [eig-v0.1.0-preview] - 2026-06-05

--- a/Frameworks/Conditional-Access-Baseline/Business-Case/ROI-CONDITIONAL-ACCESS.md
+++ b/Frameworks/Conditional-Access-Baseline/Business-Case/ROI-CONDITIONAL-ACCESS.md
@@ -19,7 +19,7 @@ Three developments distinguish v1.3 from prior releases and define its executive
 The ask of executive leadership is threefold:
 
 1. **Endorse a phased deployment** that runs each policy in report-only mode for seven to fourteen days before enforcement.
-2. **Fund or confirm** Entra ID P1 (minimum) or P2 (recommended) licensing for all in-scope users, plus Microsoft Entra Workload Identities Premium for the workload-identity policy and Microsoft Agent ID feature availability for the Agents persona policy.
+2. **Fund or confirm** Entra ID P1 (minimum) or P2 (recommended) licensing for all in-scope users, plus Microsoft Entra Workload Identities Premium for the workload-identity policy, a per-user Microsoft Agent 365 license for the Agents persona policy, and Microsoft Entra Internet Access if network-based agent controls are in scope.
 3. **Authorize a quarterly review cadence** for the baseline, led jointly by Security and IT Operations.
 
 In return, the organization gets a defensible, auditable identity security posture that addresses the single highest-probability breach vector in contemporary incident data, extends coverage to the agentic AI workload surface that most frameworks ignore, and aligns with SOC 2, ISO 27001, HIPAA, PCI-DSS, and NIST SP 800-53 access control requirements. This baseline pairs with the Intune Compliance Baseline to deliver end-to-end device-health signal integration (see `Design/CA-ICB-INTEGRATION.md`).
@@ -72,7 +72,7 @@ Twenty-four policies, each addressing a specific business risk. Policies are gro
 | CA-COV008 | Internal | Require compliant or hybrid-joined device on Windows, macOS, and Linux | Entra ID P1 + Intune | Internal users sign in to all apps only from organization-managed, healthy desktops |
 | CA-COV009 | ServiceAccounts | Block service-account sign-ins from outside the Trusted Countries named location | Entra ID P1 | Closes the coverage gap created by the ServiceAccounts persona exclusion from human-targeted policies |
 | CA-COV010 | WorkloadIdentities | Restrict service-principal sign-ins to a defined egress | Workload Identities Premium | Closes the workload-identity coverage gap left by user-scoped policies |
-| CA-COV011 | Agents | Block Agent ID sign-ins at medium or high agent risk per Identity Protection | Entra ID P2 + Agent ID | Covers the agentic AI workload surface; most community baselines ignore Agent IDs entirely |
+| CA-COV011 | Agents | Block Agent ID sign-ins at medium or high agent risk per Identity Protection | Entra ID P2 + Agent 365 (per user) | Covers the agentic AI workload surface; most community baselines ignore Agent IDs entirely |
 
 ### SIG series — Layered Signal policies
 
@@ -145,7 +145,10 @@ As of 2026, few community Conditional Access baselines include explicit coverage
 
 ### Licensing dependency
 
-CA-COV011 requires Microsoft Entra ID Premium P2 for the Identity Protection signal that surfaces agent risk. It also requires that the Microsoft Agent ID feature is available in the tenant, which is the case for tenants with Microsoft 365 Copilot or Azure AI Entra integration as of May 2026.
+Covering agents with Conditional Access carries two cost lines the organization should budget for:
+
+- **A Microsoft Agent 365 license for each user.** Conditional Access for agents requires Microsoft Entra ID P1 or P2 plus a Microsoft Agent 365 license per user. This is a per-user subscription cost on top of the existing Entra ID license. Microsoft has said it will begin enforcing the Agent 365 licensing requirement soon, so the organization should confirm this entitlement is purchased and assigned before it depends on the Agents persona for protection. Risk-based blocking of risky agents, the headline benefit of CA-COV011, requires the P2 tier of Entra ID.
+- **Microsoft Entra Internet Access for network controls.** If the organization wants to restrict agents to a trusted corporate network, that control requires the Microsoft Entra Internet Access subscription, and the Global Secure Access client must be installed on the endpoints in scope. This is a separate subscription and a software rollout, so plan for both the license cost and the deployment effort before committing to network-based agent controls.
 
 ## Beta endpoint commitment
 
@@ -172,9 +175,10 @@ For executive audiences: targeting the beta endpoint is not the same as running 
 | Microsoft Entra ID P2 — Terms of Use | CA-SIG010 | Terms of Use feature for B2B guest consent gating. The 1:5 guest-licensing ratio applies. |
 | Microsoft Entra Workload Identities Premium | CA-COV010 | Separate SKU from Entra ID P1/P2. Required for service-principal Conditional Access. |
 | Microsoft Intune | CA-COV008, CA-SIG001 | Required for `compliantDevice` grant control. Hybrid Azure AD join is an accepted alternative for both. |
-| Microsoft Agent ID feature availability | CA-COV011 | Available in tenants with Microsoft 365 Copilot or Azure AI Entra integration as of May 2026. |
+| Microsoft Agent 365 (per user) | CA-COV011 | Conditional Access for agents requires Entra ID P1 or P2 plus a Microsoft Agent 365 license per user. Risk-based enforcement requires P2. Enforcement of the Agent 365 requirement is described as coming soon. |
+| Microsoft Entra Internet Access | Agent network controls | Required for the compliant-network grant on agent policies. Relies on the Global Secure Access client on the endpoint. Separate subscription from Entra ID P1/P2. |
 
-If P1 is already licensed for all users, the incremental cost of this baseline covers the P2 upgrade for Identity Protection, PIM, and Terms of Use; the Workload Identities Premium SKU; and Agent ID availability. For organizations with Microsoft 365 Copilot licensing already in place, Agent ID availability is typically included.
+If P1 is already licensed for all users, the incremental cost of this baseline covers the P2 upgrade for Identity Protection, PIM, and Terms of Use; the Workload Identities Premium SKU; the per-user Microsoft Agent 365 license for agent coverage; and Microsoft Entra Internet Access if network-based agent controls are in scope.
 
 If P2 is not yet in place, calculate the incremental cost against the organization's Microsoft 365 agreement:
 

--- a/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
@@ -106,6 +106,16 @@ When the risk threshold is met, the response is a hard block. Agent IDs cannot s
 
 ## 5. Rollout recommendation
 
+### Licensing prerequisites
+
+Conditional Access for agents requires Microsoft Entra ID P1 or P2 plus a Microsoft Agent 365 license for each user. Microsoft describes enforcement of the Agent 365 licensing requirement as coming soon, so confirm the per-user Agent 365 entitlement is in place before you rely on this persona. Risk-based enforcement for agents through Microsoft Identity Protection, including the `agentIdRiskLevels` signal that CA-COV011 evaluates, requires Entra ID P2.
+
+Network controls for agents require Microsoft Entra Internet Access. The compliant-network grant relies on the Global Secure Access client being present on the endpoint. License Microsoft Entra Internet Access and deploy the Global Secure Access client before you add a compliant-network condition to an agent policy.
+
+Creating and managing these policies requires the Conditional Access Administrator role. The custom-security-attribute targeting method also requires the Attribute Assignment Reader role so the administrator can read the attribute values used to scope the policy.
+
+See <https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id> and <https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-autonomous-agents>.
+
 ### Pre-deployment inventory
 
 Before deploying CA-COV011 in any state, inventory the Agent IDs provisioned in the tenant:

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-EXC003-Agents-Persona.md
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-EXC003-Agents-Persona.md
@@ -96,7 +96,11 @@ When Microsoft Identity Protection raises an Agent ID risk level to `high`:
 
 The Agents persona and `CA-COV011-Agents-BlockMediumAndHighRisk` depend on features that are per-tenant and per-SKU:
 
-**Microsoft Agent ID feature availability:** As of May 2026, the Microsoft Agent ID family is available in tenants with Microsoft 365 Copilot licensing or Azure AI services configured for Entra integration. Verify that Agent IDs are provisioned in your tenant before adopting this persona. If no Agent IDs exist, `CA-COV011` will evaluate with zero matches in report-only mode — this is safe but produces no signal.
+**Conditional Access for agents licensing:** Conditional Access for agents requires Microsoft Entra ID P1 or P2 plus a Microsoft Agent 365 license for each user. Microsoft describes enforcement of the Agent 365 licensing requirement as coming soon, so confirm the per-user Agent 365 entitlement is in place before you rely on this persona. Verify that Agent IDs are provisioned in your tenant before adopting this persona. If no Agent IDs exist, `CA-COV011` will evaluate with zero matches in report-only mode, which is safe but produces no signal. See <https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id> and <https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-autonomous-agents>.
+
+**Microsoft Entra Internet Access for network controls:** Network controls for agents require Microsoft Entra Internet Access. The compliant-network grant relies on the Global Secure Access client being present on the endpoint. If you intend to add a compliant-network condition to an agent policy, license Microsoft Entra Internet Access and deploy the Global Secure Access client before enforcement.
+
+**Admin roles:** Creating and managing Conditional Access policies for agents requires the Conditional Access Administrator role. The custom-security-attribute targeting method also requires the Attribute Assignment Reader role so the administrator can read the attribute values used to scope the policy.
 
 **Microsoft Graph beta endpoint:** All Agent ID condition fields — `agentIdRiskLevels`, `IncludeAgentIdServicePrincipals`, and `IncludeApplications: ["AllAgentIdResources"]` — are Microsoft Graph beta-only as of May 2026. The baseline framework targets the beta endpoint for all 23 policies to avoid conditional endpoint logic in the deployer. See `Design/AGENTS-PERSONA-MODEL.md` for the GA promotion tracking commitment.
 

--- a/Frameworks/Conditional-Access-Baseline/README.md
+++ b/Frameworks/Conditional-Access-Baseline/README.md
@@ -168,7 +168,9 @@ Per-policy design specs (intent, principle mapping, scope, conditions, controls,
 - **Entra ID P2** (Terms of Use feature). Required by CA-SIG010. Covers guest users at the 1:5 ratio (one P2 license covers five guest users). See <https://learn.microsoft.com/en-us/entra/identity/conditional-access/terms-of-use>.
 - **Microsoft Entra Workload Identities Premium**. Required by CA-COV010. Separate SKU from Entra ID P1/P2.
 - **Microsoft Intune**. Required for `compliantDevice` grant control (CA-COV008, CA-SIG001). Hybrid Azure AD join is an accepted alternative.
-- **Microsoft Agent ID availability**. Required by CA-COV011. Available in tenants with Microsoft 365 Copilot or Azure AI Entra integration as of May 2026.
+- **Microsoft Entra ID P1 or P2 plus a Microsoft Agent 365 license per user**. Required by CA-COV011 for Conditional Access for agents. Risk-based enforcement through Identity Protection requires P2. Microsoft describes enforcement of the Agent 365 licensing requirement as coming soon.
+- **Microsoft Entra Internet Access**. Required for agent network controls. The compliant-network grant relies on the Global Secure Access client on the endpoint.
+- **Conditional Access Administrator role**. Required to create and manage agent policies. The custom-security-attribute targeting method also requires the Attribute Assignment Reader role.
 - **Microsoft Graph beta endpoint**. Required by all 23 policies. The deployer targets `https://graph.microsoft.com/beta/identity/conditionalAccess/policies`. Three policies use beta-only features (`CA-SIG003`, `CA-SIG004` use `frequencyInterval: "everyTime"`; `CA-COV011` uses the Agent ID condition family).
 - **PowerShell 7.0 or later** and the **`Microsoft.Graph.Authentication` module** for the deployer.
 - **Persona groups** created in Entra ID and populated before deployment.


### PR DESCRIPTION
Bring the Agents persona documentation into line with Microsoft's 2026-06-03 Conditional Access for Agents guidance. Conditional Access for agents requires Microsoft Entra ID P1 or P2 plus a Microsoft Agent 365 license per user (enforcement described as coming soon); agent network controls require Microsoft Entra Internet Access with the Global Secure Access client on the endpoint; and the admin roles are Conditional Access Administrator plus Attribute Assignment Reader for the custom-security-attribute targeting method. Doc-only; no policy JSON changes.