### PR TITLE
Document the three Microsoft agent access patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Documented the three Microsoft agent access patterns (on-behalf-of with the user as subject, application-only with the agent identity as subject, and agent-acting-as-a-user with the agent user account as subject), replacing the single-class agent model.
 - Verified the Agent ID Conditional Access field set against the Microsoft Graph beta reference (2026-06-03 refresh); reaffirmed the beta-endpoint commitment and flagged the unpublished AllAgentIdResources and includeAgentIdServicePrincipals All tokens as confirm-in-tenant.
 
 ### Fixed

--- a/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
@@ -10,9 +10,9 @@
 
 The Conditional Access Baseline has always distinguished between identity classes. Users, guests, service accounts, workload identities, and emergency access accounts each authenticate differently and carry different risk profiles. The baseline treats each as a distinct persona with its own policy lane.
 
-Agentic AI workloads — Microsoft 365 Copilot agents, Azure AI agents, and custom agents built on the Microsoft Copilot extensibility stack — introduce an identity class that is not a user, not a service principal, and not a managed identity. It is a Microsoft Agent ID: a new principal type that Microsoft introduced alongside its agentic AI platform and that Entra ID now surfaces as a first-class identity.
+Agentic AI workloads (Microsoft 365 Copilot agents, Azure AI agents, and custom agents built on the Microsoft Copilot extensibility stack) introduce identity behavior that is not a user, not a service principal, and not a managed identity. Microsoft Agent ID is the principal type that Entra ID surfaces for these workloads. An agent does not authenticate one single way, though. Microsoft documents three distinct agent access patterns, and each carries a different token subject and therefore a different Conditional Access targeting model. This document replaces the earlier single-class framing of the Agents persona with that three-pattern model.
 
-This document explains why Agent IDs need their own Conditional Access lane, what Microsoft Agent ID is technically, how Microsoft Identity Protection generates risk signals for Agent IDs, how the `CA-COV011-Agents-BlockMediumAndHighRisk` policy works mechanically, and what the framework's commitment is while the feature remains in beta.
+This document explains why agents need their own Conditional Access treatment, what Microsoft Agent ID is technically, the three agent access patterns and the token subject each carries, how Microsoft Identity Protection generates risk signals for Agent IDs, how the `CA-COV011-Agents-BlockMediumAndHighRisk` policy works mechanically, and what the framework's commitment is while the feature remains in beta.
 
 ---
 
@@ -48,6 +48,35 @@ A Microsoft Agent ID is not attached to an Azure resource. It is provisioned as 
 ### Why Microsoft introduced it
 
 The introduction of Agent IDs reflects a platform-level design decision by Microsoft: agentic AI workloads require identity governance separate from both human users and traditional automation (service principals, managed identities). Agents operate in a more autonomous, instruction-following mode than traditional automation. They can be directed by user-provided prompts, which creates a prompt injection threat surface that does not exist for traditional service principals. Microsoft has introduced `agentIdRiskLevels` as a risk condition specifically because the threat model for agents — particularly prompt injection and credential misuse — is meaningfully different from the threat model for traditional workload identities.
+
+### The three agent access patterns
+
+An agent does not have one fixed authentication model. Microsoft documents three access patterns, and the difference that matters for Conditional Access is the token subject each one produces. The token subject determines which targeting model reaches the sign-in. An earlier version of this framework treated agents as a single identity class targeted only through agent identity conditions. That framing covered one of the three patterns and left the other two unaddressed. The three patterns are:
+
+**Pattern 1, on-behalf-of (delegated).** A user signs into the agent, and the agent exchanges tokens through the OAuth 2.0 On-Behalf-Of flow to reach downstream resources. The token subject is the user. Conditional Access therefore targets users and groups, not agent identities. A policy that targets the agent identity does not see this flow at all; it is evaluated as a user sign-in against the user-targeted policy set.
+
+**Pattern 2, application-only (client credentials, autonomous).** The agent authenticates with its own identity using the client credentials flow, with no user present. The token subject is the agent identity. Conditional Access targets the agent identity through `includeAgentIdServicePrincipals` together with the agent application bundle. This is the pattern the baseline addresses today, via `CA-COV011-Agents-BlockMediumAndHighRisk`.
+
+**Pattern 3, agent acting as a user (agent user account, digital worker).** The agent is provisioned with its own user account, including a mailbox and group membership, and acts as a distinct digital worker. The token subject is the agent user account, which is a separate identity sub-class from the agent identity. Conditional Access targets agent users through the All agent users target (Preview). Coverage for this sub-class is planned for a later PR in the v1.4 series and is not addressed by `CA-COV011`.
+
+The three patterns map to three token subjects and three targeting models:
+
+| Access pattern | Token subject | Conditional Access targeting |
+|---|---|---|
+| On-behalf-of (delegated) | User | Users and groups |
+| Application-only (autonomous) | Agent identity | `includeAgentIdServicePrincipals` plus the agent application bundle |
+| Agent acting as a user (digital worker) | Agent user account | Agent users (All agent users, Preview) |
+
+### Limitations of the targeting models
+
+The three targeting models do not overlap, and Microsoft documents specific gaps that an adopter must account for:
+
+- A policy targeting all users does not include agent user accounts. A broad user policy leaves the agent user account uncovered.
+- Agent user accounts cannot be scoped by group membership. The group-based persona pattern used elsewhere in this baseline does not apply to them.
+- A policy targeting agent identities does not apply to the agent user account. The application-only targeting model reaches Pattern 2 only.
+- Agent identity blueprint targeting covers the agent identity, not the agent user account.
+
+These limitations are the reason the baseline addresses the application-only pattern first and treats the agent user account as a separate coverage item. See <https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id>.
 
 ---
 

--- a/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
@@ -51,6 +51,16 @@ Rather than maintain two endpoint paths, the framework commits all 24 policies t
 
 `CA-COV011-Agents-BlockMediumAndHighRisk` introduces the Agents persona. Microsoft Agent IDs are not service principals, not managed identities, and not users. They carry their own Identity Protection risk signals via `agentIdRiskLevels`. The persona is documented in `Policies/CA-EXC003-Agents-Persona.md` and fully modeled in `Design/AGENTS-PERSONA-MODEL.md`.
 
+Microsoft documents three agent access patterns, and each carries a different token subject and therefore a different Conditional Access targeting model:
+
+| Access pattern | Token subject | Conditional Access targeting | Baseline coverage |
+|---|---|---|---|
+| On-behalf-of (delegated) | User | Users and groups | Covered by the user-targeted policy set; an on-behalf-of sign-in is evaluated as a user sign-in |
+| Application-only (autonomous) | Agent identity | `includeAgentIdServicePrincipals` plus the agent application bundle | Covered by `CA-COV011-Agents-BlockMediumAndHighRisk` |
+| Agent acting as a user (digital worker) | Agent user account | Agent users (All agent users, Preview) | Planned for a later PR in the v1.4 series; not covered today |
+
+The agent user account is a distinct identity sub-class from the agent identity. A policy targeting agent identities does not apply to the agent user account, and a policy targeting all users does not include agent user accounts. The baseline addresses the application-only pattern today and treats the agent user account as a separate coverage item. See `Design/AGENTS-PERSONA-MODEL.md` section 2 for the full three-pattern model and the targeting limitations, and <https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id>.
+
 #### Per-policy exclusion judgment replaces blanket exclusion set
 
 The v1.2 architecture excluded EmergencyAccess, WorkloadIdentities, and ServiceAccounts from virtually all policies by default. v1.3 applies exclusions on a per-policy basis with documented rationale. The pattern is stricter: if a persona is excluded, Section 6 records why. If a persona is not excluded, it is in scope by design.

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-EXC003-Agents-Persona.md
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-EXC003-Agents-Persona.md
@@ -33,6 +33,14 @@ Treating the Agents persona as first-class — rather than attempting to route i
 
 **Membership rules:** Any Agent ID provisioned in the tenant is in scope for this persona. The Agents persona is not defined by group membership. Targeting is via `IncludeApplications: ["AllAgentIdResources"]` and `IncludeAgentIdServicePrincipals: ["All"]` in `CA-COV011`. This means every Agent ID in the tenant is in scope; there is no per-agent exclusion mechanism equivalent to the per-SPN `excludeServicePrincipals` list in CA-COV010.
 
+**The three agent access patterns:** An agent does not authenticate one fixed way. Microsoft documents three access patterns, and each carries a different token subject, which determines the Conditional Access targeting model:
+
+1. **On-behalf-of (delegated).** A user signs into the agent, which exchanges tokens through the OAuth 2.0 On-Behalf-Of flow for downstream resources. The token subject is the user, so Conditional Access targets users and groups, not agent identities.
+2. **Application-only (autonomous).** The agent authenticates with its own identity using the client credentials flow. The token subject is the agent identity, so Conditional Access targets the agent identity through `IncludeAgentIdServicePrincipals` plus the agent application bundle. This is the pattern this persona and `CA-COV011` cover today.
+3. **Agent acting as a user (digital worker).** The agent has its own user account with a mailbox and group membership. The token subject is the agent user account, so Conditional Access targets agent users through the All agent users target (Preview).
+
+**The agent user account is a distinct identity sub-class from the agent identity.** The agent identity (Pattern 2) and the agent user account (Pattern 3) are not the same principal. A policy targeting agent identities does not apply to the agent user account, and a policy targeting all users does not include agent user accounts. Agent user accounts also cannot be scoped by group membership, and agent identity blueprint targeting covers the agent identity, not the agent user account. This persona and `CA-COV011` cover the agent identity (Pattern 2) only; coverage for the agent user account sub-class is planned for a later PR in the v1.4 series. See `Design/AGENTS-PERSONA-MODEL.md` section 2 and <https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id>.
+
 ---
 
 ## Scope of this contract


### PR DESCRIPTION
Replace the single-class agent model with Microsoft's three documented agent access patterns, each with its correct token subject and Conditional Access targeting:

- On-behalf-of (delegated): token subject is the user; CA targets users and groups.
- Application-only (autonomous): token subject is the agent identity; CA targets the agent identity via includeAgentIdServicePrincipals plus the agent application bundle. Covered today by CA-COV011.
- Agent acting as a user (digital worker): token subject is the agent user account; CA targets agent users (All agent users, Preview). Coverage planned for a later PR.

States the targeting limitations and calls out the agent user account as a distinct identity sub-class from the agent identity. Doc-only.
