### PR TITLE
Add CA-COV012 allow-only-approved-agents policy and expand agent targeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Frameworks/Conditional-Access-Baseline/Policies/CA-COV012-Agents-AllowOnlyApprovedAgents.json and its paired contract CA-COV012-Agents-AllowOnlyApprovedAgents.md — new Agents persona allow-only policy. Includes all agent identities, excludes an approved set via `excludeAgentIdServicePrincipals` (the `REPLACE_WITH_APPROVED_AGENT_ID_OBJECT_IDS` placeholder), and blocks, so only sanctioned agents operate. The contract documents the deny-by-default-except-approved design, the two selection methods (enhanced object picker with the All / Agent blueprint principals / Agent identities tabs, and the custom security attribute method using AgentAttributes/AgentApprovalStatus and ResourceAttributes/Department with the Contains operator), the required roles (Conditional Access Administrator, plus Attribute Assignment Reader for the attribute method), and a confirm-in-tenant note that the includeAgentIdServicePrincipals "All" literal and the attribute-based targeting JSON are not yet published in the Microsoft Graph reference. Ships in report-only.
+
 ### Changed
 
 - Documented the three Microsoft agent access patterns (on-behalf-of with the user as subject, application-only with the agent identity as subject, and agent-acting-as-a-user with the agent user account as subject), replacing the single-class agent model.
 - Verified the Agent ID Conditional Access field set against the Microsoft Graph beta reference (2026-06-03 refresh); reaffirmed the beta-endpoint commitment and flagged the unpublished AllAgentIdResources and includeAgentIdServicePrincipals All tokens as confirm-in-tenant.
+- Documented the expanded agent-identity targeting options (the enhanced object picker tabs All / Agent blueprint principals / Agent identities, individual agent identities, and custom security attributes) in POLICY-DESIGN.md and AGENTS-PERSONA-MODEL.md, correcting the prior "All-only, no inclusion list" framing of the Agents persona.
+- Documented the CA-COV011 risk-threshold posture: the baseline deliberately keeps `agentIdRiskLevels = "medium,high"` as a stricter-than-recommended CHC default, noting Microsoft recommends `high` for agent-identity policies and how an adopter can align to it.
 
 ### Fixed
 

--- a/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
@@ -88,6 +88,8 @@ These limitations are the reason the baseline addresses the application-only pat
 
 In `CA-COV011`, the condition is set to `"medium,high"` — meaning the policy evaluates when Microsoft Identity Protection has raised the agent's risk level to medium or high. A `none` or `low` risk level results in the policy not applying to that authentication event.
 
+**Deviation from Microsoft's recommendation.** Microsoft recommends `agentIdRiskLevels = high` for agent-identity policies. CA-COV011 deliberately blocks at `medium,high` instead. This is a stricter-than-recommended CHC posture: blocking at medium catches a compromised or misbehaving agent one risk tier earlier, accepting a higher rate of report-only signals during the soak in exchange for earlier enforcement coverage. The stricter setting is the default. An adopter who prefers to align with Microsoft's recommendation can set `agentIdRiskLevels` to `high` in the CA-COV011 template and rename the policy accordingly.
+
 ### How Microsoft populates `agentIdRiskLevels`
 
 Microsoft Identity Protection generates agent risk detections based on signals that are specific to agentic workloads:
@@ -121,7 +123,7 @@ Limits evaluation to authentication events where Microsoft Identity Protection h
 
 **`conditions.clientApplications.includeAgentIdServicePrincipals: ["All"]`**
 
-This condition targets all Agent ID principals in the tenant. It is the Agent ID equivalent of `clientApplications.includeServicePrincipals: ["All"]` for service principals. Using `"All"` ensures every provisioned Agent ID is in scope; there is no per-agent inclusion list to maintain.
+This condition targets all Agent ID principals in the tenant. It is the Agent ID equivalent of `clientApplications.includeServicePrincipals: ["All"]` for service principals. Using `"All"` in CA-COV011 ensures every provisioned Agent ID is in scope. `"All"` is not the only available target, however: Microsoft documents selecting specific agents three ways — the enhanced object picker (tabs All, Agent blueprint principals, and Agent identities), individual agent identities by object ID, and custom security attributes (attribute set AgentAttributes with attribute AgentApprovalStatus, and attribute set ResourceAttributes with attribute Department, matched with the Contains operator). The companion property `clientApplications.excludeAgentIdServicePrincipals` takes a set of approved agent identity object IDs. These selection and exclusion methods are what `CA-COV012-Agents-AllowOnlyApprovedAgents` uses to express an allow-only posture: include all agents, exclude the approved set, block. The enhanced object picker and individual selection require the Conditional Access Administrator role; the custom security attribute method additionally requires the Attribute Assignment Reader role. See `Policies/CA-COV012-Agents-AllowOnlyApprovedAgents.md`.
 
 **`conditions.users.includeUsers: ["None"]`**
 

--- a/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
@@ -61,6 +61,10 @@ Microsoft documents three agent access patterns, and each carries a different to
 
 The agent user account is a distinct identity sub-class from the agent identity. A policy targeting agent identities does not apply to the agent user account, and a policy targeting all users does not include agent user accounts. The baseline addresses the application-only pattern today and treats the agent user account as a separate coverage item. See `Design/AGENTS-PERSONA-MODEL.md` section 2 for the full three-pattern model and the targeting limitations, and <https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id>.
 
+Agent identities are not limited to an "All-only" target with no inclusion list. Microsoft documents three ways to select the specific agents a policy applies to or exempts. The first is the enhanced object picker, which presents three tabs: All (every agent identity in the tenant), Agent blueprint principals (agents grouped by the blueprint they were provisioned from), and Agent identities (individual agents selected one at a time). The second is selecting individual agent identities by object ID. The third is custom security attributes, which select agents by attribute value rather than by enumerating object IDs. Microsoft's documented scheme uses attribute set AgentAttributes with attribute AgentApprovalStatus (values New, In_Review, HR_Approved, Finance_Approved, IT_Approved) and attribute set ResourceAttributes with attribute Department (values Finance, HR, IT, Marketing, Sales), matched with the Contains operator. The enhanced object picker and individual selection require the Conditional Access Administrator role; the custom security attribute method additionally requires the Attribute Assignment Reader role. These selection methods are what make an allow-only posture possible: `CA-COV012-Agents-AllowOnlyApprovedAgents` includes all agent identities, excludes the approved set, and blocks, so only sanctioned agents operate. See `Policies/CA-COV012-Agents-AllowOnlyApprovedAgents.md` and <https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-autonomous-agents>.
+
+`CA-COV011-Agents-BlockMediumAndHighRisk` evaluates `agentIdRiskLevels = "medium,high"`. Microsoft recommends `agentIdRiskLevels = high` for agent-identity policies. The baseline deliberately keeps `medium,high` as the stricter CHC posture: blocking at medium catches a compromised or misbehaving agent one risk tier earlier than Microsoft's high-only recommendation. This deviation is intentional and is the default; an adopter who wants to align to Microsoft's recommendation instead can set `agentIdRiskLevels` to `high` in the CA-COV011 template.
+
 #### Per-policy exclusion judgment replaces blanket exclusion set
 
 The v1.2 architecture excluded EmergencyAccess, WorkloadIdentities, and ServiceAccounts from virtually all policies by default. v1.3 applies exclusions on a per-policy basis with documented rationale. The pattern is stricter: if a persona is excluded, Section 6 records why. If a persona is not excluded, it is in scope by design.
@@ -140,7 +144,7 @@ Eight personas are defined in this baseline. Each persona maps to an identity cl
 | Guests | `users.includeGuestsOrExternalUsers` or `users.includeGroups: [CA-Persona-Guests]` | EA excluded per-policy | B2B collaboration guests, external users, service providers. |
 | ServiceAccounts | `users.includeGroups: [CA-Persona-ServiceAccounts]` | EA, WI excluded from CA-COV009 | Positive inclusion target for CA-COV009. Excluded from all human-targeted policies via CA-EXC002. |
 | WorkloadIdentities | `clientApplications.includeServicePrincipals: [ServicePrincipalsInMyTenant]` | Not applicable (not a user persona) | Inclusion target for CA-COV010. Excluded from human-targeted user policies by virtue of not being users. |
-| Agents | `clientApplications.includeAgentIdServicePrincipals: ["All"]` | Not applicable (not a user persona) | Inclusion target for CA-COV011. Microsoft Agent IDs. Persona governed by CA-EXC003. |
+| Agents | `clientApplications.includeAgentIdServicePrincipals: ["All"]`, with `excludeAgentIdServicePrincipals` for approved agents | Not applicable (not a user persona) | Inclusion target for CA-COV011 (risk-based block) and CA-COV012 (allow-only-approved). Microsoft Agent IDs. Agents are selectable via the enhanced object picker (All, Agent blueprint principals, Agent identities) or custom security attributes, not "All-only". Persona governed by CA-EXC003. |
 | EmergencyAccess | `users.excludeGroups: [CA-Persona-EmergencyAccess]` | Permanent exclusion from all policies | Exactly 2 accounts. Cloud-only. Governed by CA-EXC001. |
 
 ### 3.1 Persona group naming convention
@@ -649,6 +653,36 @@ Operational patterns for SPN per-pipeline scoping, Trusted IPs named-location re
 **Validation steps:** See `Policies/CA-EXC003-Agents-Persona.md` and `Design/AGENTS-PERSONA-MODEL.md` section 5 for the full rollout recommendation.
 
 **Exclusion rationale:** No user group exclusions are needed. The policy does not evaluate user authentication flows. See `Policies/CA-EXC003-Agents-Persona.md` for the full exclusion model.
+
+**Risk threshold posture:** Microsoft recommends `agentIdRiskLevels = high` for agent-identity policies. CA-COV011 deliberately blocks at `medium,high` instead, one tier stricter than Microsoft's recommendation, so a compromised or misbehaving agent is caught earlier. This is the default CHC posture. An adopter who prefers Microsoft's recommendation can set `agentIdRiskLevels` to `high` in the template and rename it accordingly.
+
+---
+
+### 6.14a CA-COV012-Agents-AllowOnlyApprovedAgents
+
+**Intent:** Establish an allow-only posture for the Agents persona: block every agent identity in the tenant except an approved set. Where CA-COV011 is risk-based (block on medium or high agent risk), CA-COV012 is a standing allow-list (block any agent that is not sanctioned to operate at all). The two are complementary layers, not duplicates.
+
+**Principle mapping:** 1.1 Identity-wide coverage (Agents persona) and 1.2 No standing exclusions (the approved set is a positive, governed allow-list rather than an open default).
+
+**Scope:**
+
+| Dimension | Value |
+|---|---|
+| Users | `includeUsers: ["None"]` — Agents do not authenticate as users |
+| Agent ID principals | `clientApplications.includeAgentIdServicePrincipals: ["All"]`, `excludeAgentIdServicePrincipals: ["REPLACE_WITH_APPROVED_AGENT_ID_OBJECT_IDS"]` — include all agents, exclude the approved set |
+| Applications | `includeApplications: ["All"]` — portal label "All resources (formerly 'All cloud apps')" |
+
+**Grant control:** `builtInControls: ["block"]` with `operator: "OR"`. Any in-scope agent (every agent not on the approved set) is blocked. Block is the only enforceable control for a non-human principal.
+
+**Selection of the approved set:** Two methods. The enhanced object picker (tabs All, Agent blueprint principals, Agent identities) or individual agent identity selection populates the exclude set by object ID. The custom security attribute method selects agents by attribute (AgentAttributes/AgentApprovalStatus and ResourceAttributes/Department, with the Contains operator). The object picker and individual selection require Conditional Access Administrator; the attribute method also requires Attribute Assignment Reader.
+
+**Confirm-in-tenant:** The `includeAgentIdServicePrincipals` `"All"` literal and the attribute-based targeting JSON are referenced in the Conditional Access for Agents documentation but are not yet typed in the published Microsoft Graph reference. Adopters confirm them in-tenant before REST import. See `Design/AGENTS-PERSONA-MODEL.md` section 6.
+
+**License requirements:** Same as CA-COV011 — Microsoft Entra ID P1 or P2 plus a Microsoft Agent 365 license per user; Microsoft Graph beta endpoint (all agent fields are beta-only).
+
+**Validation steps:** See `Policies/CA-COV012-Agents-AllowOnlyApprovedAgents.md`. In report-only, confirm CA-COV012 would block only unapproved or unknown agent identities and that every approved agent is present in the exclude set before enforcement.
+
+**Exclusion rationale:** No user group exclusions are needed; the policy does not evaluate user authentication flows. The agent-side exclude set is the approved-agent allow-list, not a standing bypass.
 
 ---
 

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-COV012-Agents-AllowOnlyApprovedAgents.json
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-COV012-Agents-AllowOnlyApprovedAgents.json
@@ -1,0 +1,20 @@
+{
+    "displayName": "CA-COV012-Agents-AllowOnlyApprovedAgents",
+    "state": "enabledForReportingButNotEnforced",
+    "conditions": {
+        "applications": {
+            "includeApplications": ["All"]
+        },
+        "clientApplications": {
+            "includeAgentIdServicePrincipals": ["All"],
+            "excludeAgentIdServicePrincipals": ["REPLACE_WITH_APPROVED_AGENT_ID_OBJECT_IDS"]
+        },
+        "users": {
+            "includeUsers": ["None"]
+        }
+    },
+    "grantControls": {
+        "operator": "OR",
+        "builtInControls": ["block"]
+    }
+}

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-COV012-Agents-AllowOnlyApprovedAgents.md
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-COV012-Agents-AllowOnlyApprovedAgents.md
@@ -1,0 +1,144 @@
+# CA-COV012 — Agents AllowOnlyApprovedAgents
+
+**Type:** Deployable policy template with paired operational contract
+**Status:** Report-only on first deployment (`enabledForReportingButNotEnforced`)
+**Persona:** Agents (Microsoft Agent ID)
+**Pairs with:** `CA-COV012-Agents-AllowOnlyApprovedAgents.json`
+
+---
+
+## Purpose
+
+`CA-COV012-Agents-AllowOnlyApprovedAgents` establishes an allow-list posture for the
+Agents persona. Where `CA-COV011-Agents-BlockMediumAndHighRisk` is a risk-based control
+that blocks agent identities only when Microsoft Identity Protection raises the agent risk
+level to medium or high, CA-COV012 is a standing allow-only control: every agent identity
+in the tenant is blocked unless it is on the approved set. The two policies are
+complementary. CA-COV011 governs risk; CA-COV012 governs which agents are sanctioned to
+operate at all.
+
+---
+
+## Design: deny by default, allow only the approved set
+
+The policy uses the same deny-by-default-except-approved pattern that
+`CA-COV006-Global-BlockUnknownPlatforms` uses for device platforms: include everything,
+exclude the approved set, and block. Applied to agent identities, the three conditions are:
+
+| Condition | Value | Effect |
+|---|---|---|
+| `conditions.applications.includeApplications` | `["All"]` | Scopes the policy across all resources (the portal labels this "All resources (formerly 'All cloud apps')"). |
+| `conditions.clientApplications.includeAgentIdServicePrincipals` | `["All"]` | Brings every agent identity in the tenant into scope. |
+| `conditions.clientApplications.excludeAgentIdServicePrincipals` | `["REPLACE_WITH_APPROVED_AGENT_ID_OBJECT_IDS"]` | Carves the approved agent identities back out, so they are not blocked. |
+| `conditions.users.includeUsers` | `["None"]` | Agents do not authenticate as users; this keeps the user authentication path out of scope. |
+| `grantControls.builtInControls` | `["block"]` | Any in-scope agent identity (every agent that is not on the approved set) is blocked. |
+
+The net result: an agent identity that is not on the approved set is blocked, and an agent
+identity that is on the approved set is unaffected by this policy. `block` is the only
+enforceable grant control for a non-human principal, because an agent identity cannot
+satisfy an interactive MFA, authentication strength, or device compliance challenge. This
+mirrors the block-only approach taken for service accounts (`CA-COV009`), workload
+identities (`CA-COV010`), and the agent risk control (`CA-COV011`).
+
+`excludeAgentIdServicePrincipals` takes the approved agent identity object IDs. The
+`REPLACE_WITH_APPROVED_AGENT_ID_OBJECT_IDS` placeholder is the slot for that approved set;
+populate it with the object IDs of the agent identities your organization has sanctioned
+before you import or enforce the policy.
+
+---
+
+## Selecting the approved agents
+
+Microsoft documents two methods for selecting the approved agent identities that populate
+the exclude set. Both require the Conditional Access Administrator role; the attribute
+method additionally requires the Attribute Assignment Reader role.
+
+### Method 1: the enhanced object picker
+
+The Conditional Access agent identity picker presents three tabs:
+
+- **All** — every agent identity in the tenant.
+- **Agent blueprint principals** — agents grouped by the blueprint they were provisioned
+  from, so an approval can cover all agents built on an approved blueprint.
+- **Agent identities** — individual agent identities selected one at a time.
+
+Use this method when the approved set is a known, enumerable list of individual agents or
+blueprints. The selected agent identity object IDs become the
+`excludeAgentIdServicePrincipals` set.
+
+### Method 2: custom security attributes
+
+For a larger or attribute-governed fleet, agents can be selected by custom security
+attribute rather than by enumerating object IDs. Microsoft's documented scheme uses two
+attribute sets:
+
+- Attribute set **AgentAttributes**, attribute **AgentApprovalStatus**, with the predefined
+  values `New`, `In_Review`, `HR_Approved`, `Finance_Approved`, `IT_Approved`.
+- Attribute set **ResourceAttributes**, attribute **Department**, with the values
+  `Finance`, `HR`, `IT`, `Marketing`, `Sales`.
+
+Selection uses the `Contains` operator against these attribute values, so an approved set
+can be expressed as, for example, agents whose `AgentApprovalStatus` Contains `IT_Approved`.
+The attribute method requires the Attribute Assignment Reader role in addition to the
+Conditional Access Administrator role, so the administrator can read the attribute values
+used to scope the policy.
+
+---
+
+## Roles
+
+| Role | Required for |
+|---|---|
+| Conditional Access Administrator | Creating and managing the policy, and selecting agents via the enhanced object picker. |
+| Attribute Assignment Reader | Reading the custom security attribute values when agents are selected via the attribute method. |
+
+---
+
+## Confirm-in-tenant note
+
+Two elements of this policy are referenced in the Conditional Access for Agents
+documentation but are not yet typed in the published Microsoft Graph reference, so adopters
+must confirm them against the live tenant before a REST import:
+
+1. The `includeAgentIdServicePrincipals` `"All"` literal. The Microsoft Graph reference
+   types this property as a collection of agent identity object IDs and documents no `"All"`
+   literal. The template ships `["All"]` as a confirm-in-tenant value.
+2. The attribute-based targeting JSON ("Select agent identities based on attributes"). The
+   AgentAttributes/AgentApprovalStatus and ResourceAttributes/Department scheme with the
+   `Contains` operator is documented in the Conditional Access for Agents guidance but is not
+   yet published in the Graph reference, so the wire shape must be confirmed in-tenant before
+   automated import.
+
+The confirmed properties this policy relies on are
+`conditionalAccessClientApplications.includeAgentIdServicePrincipals` and
+`excludeAgentIdServicePrincipals`, `conditions.applications.includeApplications` value
+`"All"`, `conditions.users.includeUsers` value `"None"`, and `grantControls.builtInControls`
+value `"block"`. See `Design/AGENTS-PERSONA-MODEL.md` section 6 for the full field-status
+table and the GA tracking commitment.
+
+---
+
+## Relationship to CA-COV011
+
+CA-COV011 and CA-COV012 are layered, not redundant:
+
+- **CA-COV011-Agents-BlockMediumAndHighRisk** blocks an agent identity when its risk level
+  reaches medium or high. It applies to every agent, including approved ones, because an
+  approved agent that is compromised should still be blocked on risk.
+- **CA-COV012-Agents-AllowOnlyApprovedAgents** blocks every agent identity that is not on the
+  approved set, regardless of risk level. It establishes which agents are sanctioned to
+  operate at all.
+
+Run both in report-only during the soak. Confirm that CA-COV012 would block only the agents
+you intend to keep out (unapproved or unknown agent identities) and that every approved
+agent appears in the exclude set before promoting to enforcement.
+
+---
+
+## References
+
+- <https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-autonomous-agents>
+- <https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id>
+- `Policies/CA-EXC003-Agents-Persona.md` — Agents persona contract
+- `Policies/CA-COV011-Agents-BlockMediumAndHighRisk.json` — paired risk-based agent control
+- `Design/AGENTS-PERSONA-MODEL.md` — full design rationale and beta endpoint commitment

--- a/Frameworks/Conditional-Access-Baseline/README.md
+++ b/Frameworks/Conditional-Access-Baseline/README.md
@@ -119,6 +119,7 @@ All 24 policies ship in report-only on first deployment. Operators opt in to enf
 | Policy | Intent |
 |---|---|
 | CA-COV011-Agents-BlockMediumAndHighRisk | Block Agent ID authentication when Microsoft Identity Protection detects medium or high agent risk. |
+| CA-COV012-Agents-AllowOnlyApprovedAgents | Block every agent identity except an approved set (include all agents, exclude the approved set, block). |
 
 ### Sensitive-applications scope (1)
 


### PR DESCRIPTION
Add the CA-COV012-Agents-AllowOnlyApprovedAgents policy (include all agent identities, exclude the approved set, block) with its paired contract, and reconcile the agent-identity targeting documentation.

- New policy CA-COV012 (report-only) and paired contract covering the deny-by-default-except-approved design, the enhanced object picker and custom security attribute selection methods, required roles, and confirm-in-tenant caveats for the includeAgentIdServicePrincipals "All" literal and the attribute-based targeting JSON.
- POLICY-DESIGN.md and AGENTS-PERSONA-MODEL.md: document the expanded targeting (enhanced object picker tabs, blueprints, custom security attributes), correcting the prior "All-only, no inclusion list" framing.
- Document the CA-COV011 posture: medium,high kept deliberately as the stricter CHC default, stricter than Microsoft's high-only recommendation.
- README Agents persona table gains a CA-COV012 row; headline count unchanged.
- CHANGELOG [Unreleased] Added/Changed bullets.
