### PR TITLE
Sync stale policy counts and version string to the v1.4.0 surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Synced stale policy counts and a version string in Frameworks/Conditional-Access-Baseline docs to the v1.4.0 surface (28 policies): Design/AGENTS-PERSONA-MODEL.md (version header and beta-endpoint count), Scripts/README.md (deployer table and usage counts), and Policies/CA-EXC003-Agents-Persona.md (beta-endpoint count).
+
 ---
 
 ## [1.4.0] - 2026-06-10

--- a/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
@@ -1,7 +1,7 @@
 # Agents Persona Model — Design Document
 
-**Framework:** Conditional Access Baseline v1.3
-**Status:** Preview — v1.3.0-rc.1
+**Framework:** Conditional Access Baseline v1.4
+**Status:** Preview — v1.4.0
 **Endpoint dependency:** Microsoft Graph beta (all Agent ID condition fields; GA promotion tracked below)
 
 ---
@@ -226,7 +226,7 @@ Every agent-specific Conditional Access field is Microsoft Graph beta-only. None
 
 - Agent identity blueprint targeting.
 
-The baseline framework targets the beta endpoint (`https://graph.microsoft.com/beta/identity/conditionalAccess/policies`) for all 24 policies to avoid conditional endpoint logic in the deployer. Splitting the policy set between v1.0 and beta endpoints would require maintaining two deployer code paths, two sets of test fixtures, and runtime logic to decide which endpoint applies to which policy.
+The baseline framework targets the beta endpoint (`https://graph.microsoft.com/beta/identity/conditionalAccess/policies`) for all 28 policies to avoid conditional endpoint logic in the deployer. Splitting the policy set between v1.0 and beta endpoints would require maintaining two deployer code paths, two sets of test fixtures, and runtime logic to decide which endpoint applies to which policy.
 
 **GA promotion tracking:** When Microsoft promotes the agent fields above to the v1.0 Graph API, this framework will flip the deployer endpoint to v1.0 as a single change. That change will be documented in the CHANGELOG and will not require updates to any policy JSON template, because the conditions use the same field names in both beta and v1.0. The unpublished `AllAgentIdResources` bundle and `includeAgentIdServicePrincipals` `"All"` token will be reconciled against the published reference at that time.
 

--- a/Frameworks/Conditional-Access-Baseline/Policies/CA-EXC003-Agents-Persona.md
+++ b/Frameworks/Conditional-Access-Baseline/Policies/CA-EXC003-Agents-Persona.md
@@ -178,7 +178,7 @@ The Agents persona and `CA-COV011-Agents-BlockMediumAndHighRisk` depend on featu
 
 **Admin roles:** Creating and managing Conditional Access policies for agents requires the Conditional Access Administrator role. The custom-security-attribute targeting method also requires the Attribute Assignment Reader role so the administrator can read the attribute values used to scope the policy.
 
-**Microsoft Graph beta endpoint:** All Agent ID condition fields — `agentIdRiskLevels`, `IncludeAgentIdServicePrincipals`, and `IncludeApplications: ["AllAgentIdResources"]` — are Microsoft Graph beta-only as of May 2026. The baseline framework targets the beta endpoint for all 23 policies to avoid conditional endpoint logic in the deployer. See `Design/AGENTS-PERSONA-MODEL.md` for the GA promotion tracking commitment.
+**Microsoft Graph beta endpoint:** All Agent ID condition fields — `agentIdRiskLevels`, `IncludeAgentIdServicePrincipals`, and `IncludeApplications: ["AllAgentIdResources"]` — are Microsoft Graph beta-only as of May 2026. The baseline framework targets the beta endpoint for all 28 policies to avoid conditional endpoint logic in the deployer. See `Design/AGENTS-PERSONA-MODEL.md` for the GA promotion tracking commitment.
 
 **Identity Protection for Agent IDs:** Risk-based enforcement in `CA-COV011` requires that Microsoft Identity Protection is generating `agentIdRiskLevels` signals for your tenant's Agent IDs. Identity Protection for Agent IDs is included in Entra ID P2 licensing. Verify that risk detections are appearing before treating the report-only output of CA-COV011 as a complete picture of agent risk.
 

--- a/Frameworks/Conditional-Access-Baseline/Scripts/README.md
+++ b/Frameworks/Conditional-Access-Baseline/Scripts/README.md
@@ -4,12 +4,12 @@ This folder contains deployment automation for the Conditional Access Baseline f
 
 | Script | Purpose |
 |---|---|
-| Deploy-CABaseline.ps1 | Imports all 23 CA policy templates into a Microsoft Entra tenant. Resolves tenant-specific placeholders at runtime. Defaults to report-only state. Supports `-WhatIf` for safe preview without a Graph connection. Targets the Microsoft Graph beta endpoint. |
+| Deploy-CABaseline.ps1 | Imports all 28 CA policy templates into a Microsoft Entra tenant. Resolves tenant-specific placeholders at runtime. Defaults to report-only state. Supports `-WhatIf` for safe preview without a Graph connection. Targets the Microsoft Graph beta endpoint. |
 | Get-CABaselineImpact.ps1 | Analyzes Entra sign-in logs to report what each report-only CA policy would have done if enforced. Use this before promoting any policy from `enabledForReportingButNotEnforced` to `enabled` state. Targets the Microsoft Graph beta sign-in log endpoint. |
 
 ## Beta endpoint commitment
 
-Both scripts target `https://graph.microsoft.com/beta/` endpoints. Three policies in the baseline require beta-only features: `CA-SIG003` and `CA-SIG004` use `signInFrequency.frequencyInterval: "everyTime"`, and `CA-COV011` uses the Microsoft Agent ID condition family (`agentIdRiskLevels`, `AllAgentIdResources`, `IncludeAgentIdServicePrincipals`). The framework commits to the beta endpoint for all 23 policies to keep a single deployer code path. See `Design/AGENTS-PERSONA-MODEL.md` section 6 for the GA promotion tracking commitment.
+Both scripts target `https://graph.microsoft.com/beta/` endpoints. Three policies in the baseline require beta-only features: `CA-SIG003` and `CA-SIG004` use `signInFrequency.frequencyInterval: "everyTime"`, and `CA-COV011` uses the Microsoft Agent ID condition family (`agentIdRiskLevels`, `AllAgentIdResources`, `IncludeAgentIdServicePrincipals`). The framework commits to the beta endpoint for all 28 policies to keep a single deployer code path. See `Design/AGENTS-PERSONA-MODEL.md` section 6 for the GA promotion tracking commitment.
 
 ## Prerequisites
 
@@ -68,7 +68,7 @@ Parses every JSON template in the Policies/ folder and reports what it would do.
 .\Deploy-CABaseline.ps1
 ```
 
-Creates all 23 policies in `enabledForReportingButNotEnforced` state via the beta endpoint. Policies evaluate every sign-in and log the outcome, but never block or challenge a user.
+Creates all 28 policies in `enabledForReportingButNotEnforced` state via the beta endpoint. Policies evaluate every sign-in and log the outcome, but never block or challenge a user.
 
 #### Enforced deployment (requires confirmation)
 
@@ -76,7 +76,7 @@ Creates all 23 policies in `enabledForReportingButNotEnforced` state via the bet
 .\Deploy-CABaseline.ps1 -Enforce
 ```
 
-Creates all 23 policies in `enabled` state. Prompts for confirmation before touching the tenant. Only run this after completing the report-only soak per `Design/POLICY-DESIGN.md` section 5.
+Creates all 28 policies in `enabled` state. Prompts for confirmation before touching the tenant. Only run this after completing the report-only soak per `Design/POLICY-DESIGN.md` section 5.
 
 #### Custom persona group names
 


### PR DESCRIPTION
Three CA Baseline docs were out of scope for the v1.4 PRs and still carried pre-v1.4 counts. Update AGENTS-PERSONA-MODEL.md (v1.3.0-rc.1 to v1.4.0, 24 to 28 policies), Scripts/README.md (4 instances of 23 to 28), and CA-EXC003-Agents-Persona.md (23 to 28). Docs only, no policy JSON or deployer changes. Add an Unreleased Fixed entry.
