### PR TITLE
Clear stale v1.3-era references left over after the v1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Synced stale policy counts and a version string in Frameworks/Conditional-Access-Baseline docs to the v1.4.0 surface (28 policies): Design/AGENTS-PERSONA-MODEL.md (version header and beta-endpoint count), Scripts/README.md (deployer table and usage counts), and Policies/CA-EXC003-Agents-Persona.md (beta-endpoint count).
+- Cleared stale v1.3-era references left over after the v1.4 release in Frameworks/Conditional-Access-Baseline docs: Scripts/README.md (example deployer output and Policies/ reference line still said 23 templates), Design/AGENTS-PERSONA-MODEL.md (Pattern 3 coverage now points to CA-COV013 through CA-COV015 instead of a planned later PR, and the shipped WORKLOAD-IDENTITY-IP-PATTERNS and CA-ICB-INTEGRATION design docs are no longer described as future work), Design/POLICY-DESIGN.md (intro version label), Business-Case/ROI-CONDITIONAL-ACCESS.md (current-baseline version labels), and Design/CA-ICB-INTEGRATION.md (current-baseline version labels).
 
 ---
 

--- a/Frameworks/Conditional-Access-Baseline/Business-Case/ROI-CONDITIONAL-ACCESS.md
+++ b/Frameworks/Conditional-Access-Baseline/Business-Case/ROI-CONDITIONAL-ACCESS.md
@@ -32,7 +32,7 @@ In return, the organization gets a defensible, auditable identity security postu
 
 Every year since the Verizon DBIR began tracking credential-based attacks as a distinct category, stolen or misused credentials have ranked among the top initial access vectors across industries and organization sizes. Phishing, password spray, adversary-in-the-middle token theft, and reuse of credentials exposed in third-party breaches all converge on the same point of failure: an identity that authenticates successfully with insufficient verification.
 
-The risk surface has grown. In 2026, the identity surface includes not only human users and service principals, but also AI agents operating under delegated permissions in Microsoft 365. Most identity security frameworks were designed before this identity class existed at scale. The v1.3 baseline is designed for the current attack surface, not the 2022 one.
+The risk surface has grown. In 2026, the identity surface includes not only human users and service principals, but also AI agents operating under delegated permissions in Microsoft 365. Most identity security frameworks were designed before this identity class existed at scale. The v1.4 baseline is designed for the current attack surface, not the 2022 one.
 
 ### The financial exposure is substantial
 
@@ -284,9 +284,9 @@ Deploy the risk policies — CA-SIG003, CA-SIG004, CA-SIG008, CA-SIG009 — and 
 
 ### Phase 5 — Enforcement promotion (weeks 17 to 20)
 
-Promote all remaining report-only policies to enforcement on the documented soak-completion schedule. Pair with the Intune Compliance Baseline rollout per `Design/CA-ICB-INTEGRATION.md` to ensure that the compliant-device signal that CA-COV008 and CA-SIG001 depend on is clean before enforcement decisions are made. Establish the quarterly review cadence described in the Operational cost estimate section. Declare the v1.3 baseline deployment complete.
+Promote all remaining report-only policies to enforcement on the documented soak-completion schedule. Pair with the Intune Compliance Baseline rollout per `Design/CA-ICB-INTEGRATION.md` to ensure that the compliant-device signal that CA-COV008 and CA-SIG001 depend on is clean before enforcement decisions are made. Establish the quarterly review cadence described in the Operational cost estimate section. Declare the v1.4 baseline deployment complete.
 
-Total: a twenty-week phased rollout. Up from the v1.2 estimate of twelve weeks. The extension is driven by the Agents persona soak and Agent ID inventory, the Workload Identities Trusted IPs initial setup and SPN scoping exercise, and the additional enforcement-promotion phase the larger v1.3 surface requires.
+Total: a twenty-week phased rollout. Up from the v1.2 estimate of twelve weeks. The extension is driven by the Agents persona soak and Agent ID inventory, the Workload Identities Trusted IPs initial setup and SPN scoping exercise, and the additional enforcement-promotion phase the larger v1.4 surface requires.
 
 ## References
 

--- a/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/AGENTS-PERSONA-MODEL.md
@@ -57,7 +57,7 @@ An agent does not have one fixed authentication model. Microsoft documents three
 
 **Pattern 2, application-only (client credentials, autonomous).** The agent authenticates with its own identity using the client credentials flow, with no user present. The token subject is the agent identity. Conditional Access targets the agent identity through `includeAgentIdServicePrincipals` together with the agent application bundle. This is the pattern the baseline addresses today, via `CA-COV011-Agents-BlockMediumAndHighRisk`.
 
-**Pattern 3, agent acting as a user (agent user account, digital worker).** The agent is provisioned with its own user account, including a mailbox and group membership, and acts as a distinct digital worker. The token subject is the agent user account, which is a separate identity sub-class from the agent identity. Conditional Access targets agent users through the All agent users target (Preview). Coverage for this sub-class is planned for a later PR in the v1.4 series and is not addressed by `CA-COV011`.
+**Pattern 3, agent acting as a user (agent user account, digital worker).** The agent is provisioned with its own user account, including a mailbox and group membership, and acts as a distinct digital worker. The token subject is the agent user account, which is a separate identity sub-class from the agent identity. Conditional Access targets agent users through the All agent users target (Preview). Agent user account coverage ships via `CA-COV013-AgentUsers-BlockMediumAndHighRisk`, `CA-COV014-AgentUsers-RequireCompliantDevice`, and `CA-COV015-AgentUsers-BlockNonCompliantNetwork`.
 
 The three patterns map to three token subjects and three targeting models:
 
@@ -252,10 +252,10 @@ CA-COV011 provides risk-based enforcement at the medium and high risk threshold.
 
 ---
 
-## 8. Cross-framework future hooks
+## 8. Cross-framework hooks
 
 **Defender XDR Detection Rules framework (planned Q1 2027):** The planned Defender XDR Detection Rules framework will ship hunt queries targeting Agent ID risk signals, including cross-correlation between `agentIdRiskLevels` events and Microsoft Purview audit events for data access patterns. This will provide a detection layer below the CA medium/high threshold — surfacing low-level agent anomalies that Identity Protection has not yet elevated to medium risk. The CA-COV011 policy and the Defender XDR hunt queries will be documented as complementary layers in that framework's cross-framework integration section.
 
-**Workload Identity IP Allow-Listing Patterns (PR 4):** PR 4 of the v1.3 series will add `Design/WORKLOAD-IDENTITY-IP-PATTERNS.md`, documenting egress-based controls for service principals via CA-COV010. That document will include a section on the distinction between workload identity egress controls and agent-specific controls — specifically, why IP-based allow-listing is a useful compensating control for service principals but is less applicable to Agent IDs (which may authenticate from dynamic Microsoft-managed infrastructure rather than customer-controlled egress).
+**Workload Identity IP Allow-Listing Patterns (shipped in v1.3):** `Design/WORKLOAD-IDENTITY-IP-PATTERNS.md` documents egress-based controls for service principals via CA-COV010. That document covers the distinction between workload identity egress controls and agent-specific controls, specifically why IP-based allow-listing is a useful compensating control for service principals but is less applicable to Agent IDs (which may authenticate from dynamic Microsoft-managed infrastructure rather than customer-controlled egress).
 
-**CA-ICB Integration (PR 5):** PR 5 will add `Design/CA-ICB-INTEGRATION.md`, documenting the signal handoff between the Conditional Access Baseline and the Intune Compliance Baseline. The Agent ID identity class is currently out of scope for device compliance signals (Agent IDs do not have device attributes). This will be documented as an explicit out-of-scope item in the CA-ICB integration document.
+**CA-ICB Integration (shipped in v1.3):** `Design/CA-ICB-INTEGRATION.md` documents the signal handoff between the Conditional Access Baseline and the Intune Compliance Baseline. The Agent ID identity class is currently out of scope for device compliance signals (Agent IDs do not have device attributes), and the CA-ICB integration document records this as an explicit out-of-scope item.

--- a/Frameworks/Conditional-Access-Baseline/Design/CA-ICB-INTEGRATION.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/CA-ICB-INTEGRATION.md
@@ -1,12 +1,12 @@
 # Conditional Access Baseline — Intune Compliance Baseline Integration
 
-Cross-framework integration specification: how the v1.3 Conditional Access Baseline consumes the Intune Compliance Baseline compliance signal. This document is required reading before enforcing CA-COV008-Internal-RequireCompliantDeviceOnDesktops, CA-SIG001-SensitiveApps-RequireCompliantDevice, or CA-SIG007-Internal-TokenProtection.
+Cross-framework integration specification: how the v1.4 Conditional Access Baseline consumes the Intune Compliance Baseline compliance signal. This document is required reading before enforcing CA-COV008-Internal-RequireCompliantDeviceOnDesktops, CA-SIG001-SensitiveApps-RequireCompliantDevice, or CA-SIG007-Internal-TokenProtection.
 
 ---
 
 ## 1. Introduction
 
-Three policies in the v1.3 Conditional Access Baseline depend on a device compliance signal that originates outside the CA framework entirely:
+Three policies in the v1.4 Conditional Access Baseline depend on a device compliance signal that originates outside the CA framework entirely:
 
 - **CA-COV008-Internal-RequireCompliantDeviceOnDesktops** — uses a `compliantDevice` or `domainJoinedDevice` grant control for Internal users on Windows, macOS, and Linux. Either the device is Intune-compliant or it is hybrid Azure AD joined; if neither is true, access is blocked regardless of the user's authentication strength or risk level.
 - **CA-SIG001-SensitiveApps-RequireCompliantDevice** — applies the same `compliantDevice` or `domainJoinedDevice` grant for Internal users accessing Azure Service Management. The highest-value application in most Microsoft 365 tenants cannot be reached from an unmanaged device.
@@ -101,11 +101,11 @@ The dashed line from the Entra device object to the CA evaluation step reflects 
 
 ---
 
-## 4. CA policies in v1.3 that consume the ICB signal
+## 4. CA policies in v1.4 that consume the ICB signal
 
-This section documents the three CA policies in v1.3 that depend on the ICB compliance signal. For each policy, the grant control mechanic, user and application scope, required ICB policy assignment, and satisfying `complianceState` values are documented. The table below summarizes the key characteristics at a glance; the per-policy subsections provide the full specification.
+This section documents the three CA policies in v1.4 that depend on the ICB compliance signal. For each policy, the grant control mechanic, user and application scope, required ICB policy assignment, and satisfying `complianceState` values are documented. The table below summarizes the key characteristics at a glance; the per-policy subsections provide the full specification.
 
-**Summary of ICB signal consumers in v1.3:**
+**Summary of ICB signal consumers in v1.4:**
 
 | Policy | Grant mechanism | Application scope | Required ICB policy | Satisfying device state |
 |---|---|---|---|---|

--- a/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
+++ b/Frameworks/Conditional-Access-Baseline/Design/POLICY-DESIGN.md
@@ -1,6 +1,6 @@
 # Conditional Access Baseline — Policy Design
 
-This document specifies the design philosophy, naming convention, persona model, exclusion strategy, rollout sequence, and per-policy design specifications for the Conditional Access Baseline framework (v1.3). It is the prerequisite reading for anyone deploying, extending, or auditing the baseline.
+This document specifies the design philosophy, naming convention, persona model, exclusion strategy, rollout sequence, and per-policy design specifications for the Conditional Access Baseline framework (v1.4). It is the prerequisite reading for anyone deploying, extending, or auditing the baseline.
 
 ---
 

--- a/Frameworks/Conditional-Access-Baseline/Scripts/README.md
+++ b/Frameworks/Conditional-Access-Baseline/Scripts/README.md
@@ -112,12 +112,12 @@ Successful report-only deployment produces output similar to:
 [OK]     REPLACE_WITH_STANDARDAUTH_STRENGTH_ID -> <guid>
 [OK]     REPLACE_WITH_STRONGAUTH_STRENGTH_ID -> <guid>
 [OK]     REPLACE_WITH_ADMINAUTH_STRENGTH_ID -> <guid>
-[OK]   Found 23 policy templates in ../Policies
+[OK]   Found 28 policy templates in ../Policies
 [INFO] Processing: CA-AUT001-Global-RegisterDevice.json
 [OK]     Created: CA-AUT001-Global-RegisterDevice [<guid>]
 [INFO] Processing: CA-AUT002-Global-RegisterSecurityInfo.json
 ... (one entry per template) ...
-[INFO] Created: 23  Previewed: 0  Errors: 0
+[INFO] Created: 28  Previewed: 0  Errors: 0
 [INFO] Reminder: Policies are in report-only mode. Soak, validate with Get-CABaselineImpact.ps1, and promote per Design/POLICY-DESIGN.md section 5.
 ```
 
@@ -210,6 +210,6 @@ Before promoting a policy from report-only to enabled state:
 ## Reference
 
 - `Design/POLICY-DESIGN.md` — baseline philosophy, naming convention, persona model, rollout sequence, per-policy specs
-- `Policies/` — the 23 JSON policy templates consumed by Deploy-CABaseline.ps1
+- `Policies/` — the 28 JSON policy templates consumed by Deploy-CABaseline.ps1
 - `Design/AGENTS-PERSONA-MODEL.md` — Microsoft Agent ID technical overview and beta endpoint commitment
 - Root README — framework overview and deployment workflow


### PR DESCRIPTION
Scripts/README.md: update the example deployer output and the Policies/ reference line from 23 to 28 templates. AGENTS-PERSONA-MODEL.md: point Pattern 3 agent user account coverage at CA-COV013 through CA-COV015 instead of a planned later PR, and describe the shipped WORKLOAD-IDENTITY-IP-PATTERNS and CA-ICB-INTEGRATION design docs in present tense. POLICY-DESIGN.md, ROI-CONDITIONAL-ACCESS.md, and CA-ICB-INTEGRATION.md: update current-framework version labels from v1.3 to v1.4, leaving historical v1.3 references intact. Add an Unreleased Fixed entry to the root CHANGELOG. Docs only.
