### PR TITLE
fix(ztra): guard @odata.nextLink and value access against strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `Invoke-ZTGraphRequest` in `Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Get-ZTReadinessScore.ps1`:
+  direct property access on `$response.'@odata.nextLink'` and `$response.value` threw
+  `PropertyNotFoundException` under `Set-StrictMode -Version Latest` when the API response
+  contained no next-page link or no `.value` collection (single-object endpoints). Both
+  replaced with `PSObject.Properties.Name -contains` guards. Confirmed against
+  `cloudharbordemo.onmicrosoft.com`: previously exited on first CA policy fetch; now proceeds.
 - Synced stale policy counts and a version string in Frameworks/Conditional-Access-Baseline docs to the v1.4.0 surface (28 policies): Design/AGENTS-PERSONA-MODEL.md (version header and beta-endpoint count), Scripts/README.md (deployer table and usage counts), and Policies/CA-EXC003-Agents-Persona.md (beta-endpoint count).
 - Corrected repo-wide documentation consistency issues outside the Conditional Access Baseline: the three broken POLICY-DESIGN.md links in Frameworks/Intune-Compliance-Baseline/README.md now point to Design/POLICY-DESIGN.md, the four malformed CHANGELOG footer link definitions (1.2.0, 1.1.0, 1.0.1, 1.0.0) no longer carry a space before the colon, the Entra ID Governance Toolkit row in the root README Frameworks table now carries its 2026-06-05 release date, and the Security Reporting Decision Rubric status banner now reflects the pending, not-yet-tagged state to match the root README table.
 - Cleared stale v1.3-era references left over after the v1.4 release in Frameworks/Conditional-Access-Baseline docs: Scripts/README.md (example deployer output and Policies/ reference line still said 23 templates), Design/AGENTS-PERSONA-MODEL.md (Pattern 3 coverage now points to CA-COV013 through CA-COV015 instead of a planned later PR, and the shipped WORKLOAD-IDENTITY-IP-PATTERNS and CA-ICB-INTEGRATION design docs are no longer described as future work), Design/POLICY-DESIGN.md (intro version label), Business-Case/ROI-CONDITIONAL-ACCESS.md (current-baseline version labels), and Design/CA-ICB-INTEGRATION.md (current-baseline version labels).

--- a/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Get-ZTReadinessScore.ps1
+++ b/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Get-ZTReadinessScore.ps1
@@ -70,12 +70,18 @@ function Invoke-ZTGraphRequest {
     $results = [System.Collections.Generic.List[object]]::new()
     do {
         $response = Invoke-MgGraphRequest -Method GET -Uri $fullUri -OutputType PSObject
-        if ($null -ne $response.value) {
+        $hasValue = ($null -ne $response) -and
+                    ($response.PSObject.Properties.Name -contains 'value')
+        if ($hasValue) {
             $results.AddRange([object[]]($response.value))
         } else {
             return $response
         }
-        $fullUri = $response.'@odata.nextLink'
+        $fullUri = if ($response.PSObject.Properties.Name -contains '@odata.nextLink') {
+            $response.'@odata.nextLink'
+        } else {
+            $null
+        }
     } while ($fullUri)
     return $results.ToArray()
 }


### PR DESCRIPTION
Fixes Invoke-ZTGraphRequest in Get-ZTReadinessScore.ps1. Set-StrictMode -Version Latest throws PropertyNotFoundException when \.'@odata.nextLink' is accessed on a PSObject that has no next-page link (small result sets). Same trap exists for \.value on single-object endpoints. Both are replaced with PSObject.Properties.Name -contains checks. Confirmed against cloudharbordemo.onmicrosoft.com: the script previously exited with PropertyNotFoundException on the first CA policy fetch; fix allows the collector to proceed past that call. Targets ztra-v0.1.0-preview.