### PR TITLE
fix(ztra): correct PIM Graph endpoints to the unified role-management model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected the PIM data-collection endpoints in `Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Get-ZTReadinessScore.ps1`
+  (controls ID-02, ID-06). The collector called the deprecated Azure AD PIM API
+  `GET /beta/privilegedAccess/aadRoles/resources/{tenantId}/roleAssignments`, which no longer
+  resolves and always fell through to `ManualReview`. Replaced with the current PIM v3 unified
+  role-management endpoints (v1.0 GA): eligible assignments via
+  `GET /roleManagement/directory/roleEligibilityScheduleInstances` and permanent standing
+  assignments via `GET /roleManagement/directory/roleAssignmentScheduleInstances` filtered to
+  `assignmentType eq 'Assigned'` with a null `endDateTime`. IN-01 (PIM for Azure resource roles)
+  is Azure Resource Manager-only — not exposed by Microsoft Graph — so its dead beta call was
+  removed and the control is now a direct `ManualReview`. Dropped the now-unused
+  `PrivilegedAccess.Read.AzureAD` scope (the collector runs on 6 read-only scopes; the new
+  endpoints are covered by the existing `RoleManagement.Read.Directory`). Updated the framework
+  README, Scripts/README, and the SCORING-RUBRIC M365 Signal fields (ID-02, ID-06, IN-01, IN-04)
+  to cite the correct endpoints.
 - Fixed a runtime failure in `Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Get-ZTReadinessScore.ps1`
   where three `New-ZTControl` calls (ID-02, ID-06, IN-01) passed an `if`/`else` statement to
   `-ManualReviewNote` using grouping parentheses — `(if ... { } else { })`. In argument position

--- a/Frameworks/Zero-Trust-Readiness-Assessment/Design/SCORING-RUBRIC.md
+++ b/Frameworks/Zero-Trust-Readiness-Assessment/Design/SCORING-RUBRIC.md
@@ -76,7 +76,7 @@ This rubric is usable without the collector script. The collector script (`Scrip
 | 3 — Advanced | Phishing-resistant MFA enforced for admins via dedicated CA policy. Sign-in risk CA targets admin personas. PIM deployed with eligible assignments for most admin roles. |
 | 4 — Optimal | All admin roles in PIM eligible — zero permanent assignments except break-glass. JIT activation requires approval and justification. Dedicated admin accounts separate from daily-use accounts. Real-time risk response automated. |
 
-**M365 Signal:** CA policy targeting admin role set with phishing-resistant auth strength in enforced mode. PIM eligible assignment count vs. permanent assignment count across directory roles via `GET /privilegedAccess/aadRoles/resources/{tenantId}/roleAssignments`.
+**M365 Signal:** CA policy targeting admin role set with phishing-resistant auth strength in enforced mode. PIM eligible assignment count via `GET /roleManagement/directory/roleEligibilityScheduleInstances`; permanent standing assignment count via `GET /roleManagement/directory/roleAssignmentScheduleInstances` filtered to `assignmentType eq 'Assigned'` with a null `endDateTime`.
 
 ---
 
@@ -140,7 +140,7 @@ This rubric is usable without the collector script. The collector script (`Scrip
 | 3 — Advanced | Majority of admin roles eligible via PIM. Activation requires approval for high-impact roles (Global Admin, Privileged Role Admin, Security Admin). PIM audit logs reviewed regularly. Emergency access accounts exist and are monitored. |
 | 4 — Optimal | Zero permanent admin assignments except documented break-glass accounts. All role activations time-limited. Activation triggers automated alert. PIM access reviews run on all eligible assignments. Break-glass account usage monitored continuously. |
 
-**M365 Signal:** `GET /privilegedAccess/aadRoles/resources/{tenantId}/roleAssignments` — eligible vs. permanent assignment ratio. PIM role settings requiring approval for high-impact roles.
+**M365 Signal:** `GET /roleManagement/directory/roleEligibilityScheduleInstances` and `GET /roleManagement/directory/roleAssignmentScheduleInstances` — eligible vs. permanent standing assignment ratio (permanent = `assignmentType eq 'Assigned'` with null `endDateTime`). PIM role settings requiring approval via `GET /policies/roleManagementPolicyAssignments`.
 
 ---
 
@@ -526,7 +526,7 @@ This rubric is usable without the collector script. The collector script (`Scrip
 | 3 — Advanced | PIM covers both Entra directory roles and Azure resource roles for key subscriptions. Activation requires justification and MFA. High-impact role activations require approval. Time-bound access enforced. |
 | 4 — Optimal | Zero permanent assignments for Azure resource roles except documented break-glass. All activations time-limited. Activation triggers automated alert. Azure resource role usage audited continuously. Emergency access process documented and tested. |
 
-**M365 Signal:** `GET /privilegedAccess/azureResources/resources/{resourceId}/roleAssignments` — eligible vs. permanent ratio for Azure resource roles. Activation policy configuration for requiring approval.
+**M365 Signal:** Eligible vs. permanent ratio for Azure resource roles is an Azure Resource Manager signal (`Microsoft.Authorization/roleEligibilityScheduleInstances` and `roleAssignmentScheduleInstances`), not available via Microsoft Graph — manual review in the Graph-only v0.1.0-preview collector.
 
 ---
 
@@ -574,7 +574,7 @@ This rubric is usable without the collector script. The collector script (`Scrip
 | 3 — Advanced | Least-privilege RBAC applied at resource group level. Owner role usage minimized. RBAC assignments reviewed quarterly. Custom roles documented and scoped tightly. |
 | 4 — Optimal | Least privilege enforced at resource and resource-group level. No standing Owner or Contributor access except for automation identities managed via PIM. RBAC assignments reviewed automatically. Privileged resource assignments gated by PIM activation. |
 
-**M365 Signal:** Azure RBAC Owner and Contributor assignment count at subscription level is an Azure Management API signal. PIM coverage for Azure resource roles is available via `GET /privilegedAccess/azureResources`.
+**M365 Signal:** Azure RBAC Owner and Contributor assignment count at subscription level is an Azure Management API signal. PIM coverage for Azure resource roles is an Azure Resource Manager signal (`Microsoft.Authorization/roleEligibilityScheduleInstances`), not available via Microsoft Graph.
 
 ---
 

--- a/Frameworks/Zero-Trust-Readiness-Assessment/README.md
+++ b/Frameworks/Zero-Trust-Readiness-Assessment/README.md
@@ -26,7 +26,7 @@ Per-pillar stage = median of all control row scores within the pillar. Overall t
 | Artifact | Description |
 |---|---|
 | `Design/SCORING-RUBRIC.md` | Full assessment rubric — 6 pillars × 4 CISA ZTMM stages. Each control row includes NIST tenet citations, the observable M365 configuration signal used to score it, and a cross-reference to a deployed repo artifact where applicable. Usable without the collector script. |
-| `Scripts/Get-ZTReadinessScore.ps1` | Read-only Microsoft Graph collector. Runs against a live tenant using 7 delegated/application scopes (no write permissions) and returns a structured object consumed by the formatter. |
+| `Scripts/Get-ZTReadinessScore.ps1` | Read-only Microsoft Graph collector. Runs against a live tenant using 6 delegated/application scopes (no write permissions) and returns a structured object consumed by the formatter. |
 | `Scripts/Format-ZTReadinessReport.ps1` | Accepts the collector output and generates three Markdown reports: technical detail, executive summary, and board 1-pager. |
 | `Scripts/README.md` | Prerequisites, authentication setup, and end-to-end usage examples for both scripts. |
 | `Examples/Board-Summary-Template.md` | Blank board 1-pager template for practitioners who run the assessment manually against the rubric. |
@@ -47,7 +47,6 @@ The collector script uses read-only scopes only:
 | `Device.Read.All` | Endpoints |
 | `RoleManagement.Read.Directory` | Identities, Infrastructure |
 | `Reports.Read.All` | Cross-pillar |
-| `PrivilegedAccess.Read.AzureAD` | Identities, Infrastructure |
 
 ---
 

--- a/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Get-ZTReadinessScore.ps1
+++ b/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Get-ZTReadinessScore.ps1
@@ -23,8 +23,7 @@
     Author:   Cloud Harbor Consulting LLC
     Requires: PowerShell 7+, Microsoft.Graph.Authentication module
     Scopes:   Policy.Read.All, IdentityRiskyUser.Read.All, AuditLog.Read.All,
-              Device.Read.All, RoleManagement.Read.Directory, Reports.Read.All,
-              PrivilegedAccess.Read.AzureAD
+              Device.Read.All, RoleManagement.Read.Directory, Reports.Read.All
 #>
 [CmdletBinding()]
 param(
@@ -41,8 +40,7 @@ $REQUIRED_SCOPES = @(
     'AuditLog.Read.All',
     'Device.Read.All',
     'RoleManagement.Read.Directory',
-    'Reports.Read.All',
-    'PrivilegedAccess.Read.AzureAD'
+    'Reports.Read.All'
 )
 # ── Helper functions ──────────────────────────────────────────────────────────
 function Write-Status {
@@ -219,9 +217,14 @@ $adminSignInRiskCA = Test-CAPolicyExists -Policies $caPolicies -Filter {
     ((Get-ZTProp $p 'conditions.signInRiskLevels') | Measure-Object).Count -gt 0
 }
 $pimData = try {
-    $assignments = Invoke-ZTGraphRequest -Uri "privilegedAccess/aadRoles/resources/$TenantId/roleAssignments" -ApiVersion 'beta'
-    $eligible  = @($assignments | Where-Object { (Get-ZTProp $_ 'assignmentState') -eq 'Eligible' }).Count
-    $permanent = @($assignments | Where-Object { (Get-ZTProp $_ 'assignmentState') -eq 'Active'   }).Count
+    # PIM for Microsoft Entra roles — unified role-management model (v1.0 GA).
+    # Eligible = roleEligibilityScheduleInstances; permanent standing = roleAssignmentScheduleInstances
+    # where assignmentType is 'Assigned' (not 'Activated') and endDateTime is null (perpetual).
+    $eligible  = @(Invoke-ZTGraphRequest -Uri 'roleManagement/directory/roleEligibilityScheduleInstances').Count
+    $active    = @(Invoke-ZTGraphRequest -Uri 'roleManagement/directory/roleAssignmentScheduleInstances')
+    $permanent = @($active | Where-Object {
+        (Get-ZTProp $_ 'assignmentType') -eq 'Assigned' -and $null -eq (Get-ZTProp $_ 'endDateTime')
+    }).Count
     @{ Eligible = $eligible; Permanent = $permanent }
 } catch {
     Write-Status 'PIM role assignment data unavailable — flagging ManualReview for ID-02 and ID-06.' -Level Warn
@@ -235,7 +238,7 @@ $id02Stage = if ($null -eq $pimData) { $null }
 $idControls.Add((New-ZTControl -Id 'ID-02' -Name 'Admin MFA and privileged identity protection' `
     -NistTenets @('T3','T4','T6') -RepoXRef 'CA-AUT001-003, CA-SIG005' -Stage $id02Stage `
     -ManualReview ($null -eq $pimData) `
-    -ManualReviewNote $(if ($null -eq $pimData) { 'PIM role assignment data not returned. Review in Entra admin center > Identity Governance > Privileged Identity Management > Azure AD roles > Assignments.' } else { '' }) `
+    -ManualReviewNote $(if ($null -eq $pimData) { 'PIM role assignment data not returned. Review in Entra admin center > Identity Governance > Privileged Identity Management > Microsoft Entra roles > Assignments.' } else { '' }) `
     -Signal @{ AdminMfaEnforced = $adminMfaEnforced; AdminSignInRiskCA = $adminSignInRiskCA; PimData = $pimData }))
 # ID-03: Block legacy authentication
 $legacyBlockEnforced = Test-CAPolicyExists -Policies $caPolicies -Filter {
@@ -301,7 +304,7 @@ $id06Stage = if ($null -eq $pimData) { $null }
 $idControls.Add((New-ZTControl -Id 'ID-06' -Name 'Privileged identity management JIT access' `
     -NistTenets @('T3','T4','T5') -RepoXRef 'EIG-AR002' -Stage $id06Stage `
     -ManualReview ($null -eq $pimData) `
-    -ManualReviewNote $(if ($null -eq $pimData) { 'PIM data unavailable. Review in Entra admin center > Identity Governance > PIM > Azure AD roles > Assignments.' } else { '' }) `
+    -ManualReviewNote $(if ($null -eq $pimData) { 'PIM data unavailable. Review in Entra admin center > Identity Governance > PIM > Microsoft Entra roles > Assignments.' } else { '' }) `
     -Signal @{ PimData = $pimData }))
 # ID-07: External identity lifecycle governance
 $authPolicy        = try { Invoke-ZTGraphRequest -Uri 'policies/authorizationPolicy' } catch { $null }
@@ -482,26 +485,14 @@ Write-Status "Pillar 4 (Data) stage: $pillar4Stage" -Level OK
 Write-Status 'Assessing Pillar 5 — Infrastructure...'
 $infraControls = [System.Collections.Generic.List[PSCustomObject]]::new()
 $azureNote     = 'Requires Azure Management API signals, outside v0.1.0-preview Graph-only scope.'
-# IN-01: JIT privileged access for Azure resource roles
-$azureResPim = try {
-    $ra = Invoke-ZTGraphRequest -Uri 'privilegedAccess/azureResources/roleAssignments' -ApiVersion 'beta'
-    $e  = @($ra | Where-Object { (Get-ZTProp $_ 'assignmentState') -eq 'Eligible' }).Count
-    $p  = @($ra | Where-Object { (Get-ZTProp $_ 'assignmentState') -eq 'Active'   }).Count
-    @{ Eligible = $e; Permanent = $p }
-} catch {
-    Write-Status 'Azure resource PIM data unavailable — flagging ManualReview for IN-01.' -Level Warn
-    $null
-}
-$in01Stage = if ($null -eq $azureResPim) { $null }
-             elseif ($azureResPim.Permanent -eq 0 -and $azureResPim.Eligible -gt 0) { 4 }
-             elseif ($azureResPim.Eligible -ge $azureResPim.Permanent)               { 3 }
-             elseif ($azureResPim.Eligible -gt 0)                                    { 2 }
-             else                                                                    { 1 }
+# IN-01: JIT privileged access for Azure resource roles — ARM-only, not available via Microsoft Graph.
+# PIM for Azure resource roles is managed through the Azure Resource Manager APIs
+# (Microsoft.Authorization/roleEligibilityScheduleInstances), not Microsoft Graph, so this control
+# is manual-review in the Graph-only v0.1.0-preview collector.
 $infraControls.Add((New-ZTControl -Id 'IN-01' -Name 'JIT privileged access for Azure resource roles' `
-    -NistTenets @('T3','T4','T5') -RepoXRef 'EIG-AR002' -Stage $in01Stage `
-    -ManualReview ($null -eq $azureResPim) `
-    -ManualReviewNote $(if ($null -eq $azureResPim) { 'Azure resource PIM data not returned. Review in Entra admin center > Identity Governance > PIM > Azure resources > Assignments.' } else { '' }) `
-    -Signal @{ AzureResourcePim = $azureResPim }))
+    -NistTenets @('T3','T4','T5') -RepoXRef 'EIG-AR002' -Stage $null -ManualReview $true `
+    -ManualReviewNote "$azureNote PIM for Azure resource roles is managed via the Azure Resource Manager APIs, not Microsoft Graph. Review in Entra admin center > Identity Governance > Privileged Identity Management > Azure resources > Assignments." `
+    -Signal @{}))
 # IN-02: Workload identity — managed identities vs. secrets
 $appRegs      = try { Invoke-ZTGraphRequest -Uri 'applications' } catch { @() }
 $staleSecrets = @($appRegs | Where-Object {

--- a/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/README.md
+++ b/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/README.md
@@ -8,7 +8,7 @@ This folder contains two scripts for the Zero Trust Readiness Assessment Framewo
 |---|---|
 | PowerShell | 7.0 or later |
 | Module | `Microsoft.Graph.Authentication` — install via `Install-Module Microsoft.Graph.Authentication` |
-| Permissions | Global Reader, or a custom role granting the 7 Graph scopes below |
+| Permissions | Global Reader, or a custom role granting the 6 Graph scopes below |
 | License | Entra ID P2 required for PIM and ID Protection signals (ID-02, ID-04–ID-06) |
 ---
 ## Required Graph scopes
@@ -18,9 +18,8 @@ This folder contains two scripts for the Zero Trust Readiness Assessment Framewo
 | `IdentityRiskyUser.Read.All` | Identities (risky user count) |
 | `AuditLog.Read.All` | Cross-pillar (sign-in logs) |
 | `Device.Read.All` | Endpoints (device registration and join type) |
-| `RoleManagement.Read.Directory` | Identities (directory role assignments) |
+| `RoleManagement.Read.Directory` | Identities (directory role assignments; PIM role eligibility/assignment schedule instances) |
 | `Reports.Read.All` | Cross-pillar (authentication method registration) |
-| `PrivilegedAccess.Read.AzureAD` | Identities, Infrastructure (PIM assignments) |
 ---
 ## Authentication
 **Interactive (recommended for initial assessment):**
@@ -97,7 +96,7 @@ lists all controls requiring manual assessment in v0.1.0-preview and why.
 | DA-05 | Purview IRM not in Graph | Purview compliance portal > Insider risk management |
 | DA-06 | Purview retention not in Graph | Purview compliance portal > Data lifecycle management |
 | DA-07 | Purview Content Explorer not in Graph | Purview compliance portal > Content explorer |
-| IN-01* | Azure resource PIM may be inaccessible | Entra admin center > PIM > Azure resources |
+| IN-01 | PIM for Azure resource roles is managed via the Azure Resource Manager APIs, not Microsoft Graph | Entra admin center > PIM > Azure resources |
 | IN-02* | Managed identity coverage requires Azure Management API | Azure portal > resource > Identity |
 | IN-03 | Defender for Cloud + Sentinel require Azure Management API | Defender for Cloud + Sentinel |
 | IN-04 | Azure RBAC requires Azure Management API | Azure portal > Subscriptions > IAM |


### PR DESCRIPTION
Corrects the collector''s PIM data collection (controls ID-02, ID-06) and aligns the framework docs.

## Problem
`Get-ZTReadinessScore.ps1` called the deprecated Azure AD PIM API
`GET /beta/privilegedAccess/aadRoles/resources/{tenantId}/roleAssignments`, which no longer
resolves — so ID-02 and ID-06 always fell through to `ManualReview` even in tenants with PIM.

## Fix
- **ID-02 / ID-06** now use the PIM v3 unified role-management endpoints (v1.0 GA):
  - eligible → `GET /roleManagement/directory/roleEligibilityScheduleInstances`
  - permanent standing → `GET /roleManagement/directory/roleAssignmentScheduleInstances`, filtered to `assignmentType eq ''Assigned''` with a null `endDateTime`.
- **IN-01** (PIM for Azure resource roles) is Azure Resource Manager-only — not exposed by Microsoft Graph — so the dead beta `azureResources` call was removed and the control is now a direct `ManualReview`.
- **Scopes:** dropped the now-unused `PrivilegedAccess.Read.AzureAD`; the collector runs on **6** read-only scopes (the new endpoints are covered by the existing `RoleManagement.Read.Directory`).
- **Docs:** updated the framework `README.md`, `Scripts/README.md`, and the `SCORING-RUBRIC.md` M365 Signal fields (ID-02, ID-06, IN-01, IN-04) to cite the correct endpoints.

## Validation
Endpoints and the `assignmentType`/`endDateTime` semantics verified against the Microsoft Graph v1.0 PIM documentation. AST parse + strict-mode logic harness passed locally. Confirmed live against `cloudharbordemo.onmicrosoft.com`: the PIM endpoints resolve, all six pillars score (Overall Stage 2 — Initial), and the JSON export succeeds.

Part of the ztra-v0.1.0-preview fix series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)