### PR TITLE
fix(ztra): correct misattributed Zero Trust breach-cost statistic in board output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected a misattributed breach-cost statistic in the ZTRA board report output
+  (`Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Format-ZTReadinessReport.ps1`) and in
+  `Examples/Sample-Tenant-Report.md`. Both stated that "organizations with a mature Zero Trust
+  program average $1.76M less per breach" and attributed it to the IBM Cost of a Data Breach 2024
+  report. That report publishes no Zero Trust-specific breakdown; in the 2024 edition $1.76M is the
+  additional cost borne by organizations with severe security staffing shortages. The $1.76M Zero
+  Trust figure is genuine but originates in IBM's 2021 report (mature Zero Trust $3.28M per breach
+  versus $5.04M for organizations that had not deployed Zero Trust). The board report now cites the
+  2021 edition explicitly and states both underlying figures, while continuing to source the current
+  $4.88M global / $9.36M US averages from the 2024 report. The 2021 edition is the most recent to
+  publish a Zero Trust-specific cut.
 - Corrected the PIM data-collection endpoints in `Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Get-ZTReadinessScore.ps1`
   (controls ID-02, ID-06). The collector called the deprecated Azure AD PIM API
   `GET /beta/privilegedAccess/aadRoles/resources/{tenantId}/roleAssignments`, which no longer

--- a/Frameworks/Zero-Trust-Readiness-Assessment/Examples/Sample-Tenant-Report.md
+++ b/Frameworks/Zero-Trust-Readiness-Assessment/Examples/Sample-Tenant-Report.md
@@ -284,9 +284,10 @@ device CA policy and enforced MFA coverage set, an attacker who obtains a valid 
 access corporate resources from any device.
 
 The IBM Cost of a Data Breach 2024 report places the average breach cost at $4.88M globally
-($9.36M in the United States). Organizations with a mature Zero Trust program average $1.76M
-less per breach than organizations without one. A Stage 2 organization typically falls into the
-higher-cost breach category.
+($9.36M in the United States). IBM's 2021 report, the most recent edition to publish a Zero
+Trust-specific breakdown, found that organizations with a mature Zero Trust strategy averaged
+$3.28M per breach compared with $5.04M for organizations that had not deployed Zero Trust, a
+difference of $1.76M. A Stage 2 organization typically falls into the higher-cost breach category.
 
 ---
 

--- a/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Format-ZTReadinessReport.ps1
+++ b/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Format-ZTReadinessReport.ps1
@@ -300,7 +300,7 @@ $b.Add('- **Credential attacks succeeding** — phishing, password spray, and MF
 $b.Add('- **Lateral movement going undetected** — without device compliance enforcement and endpoint telemetry, an attacker who gains access to one account can move freely.')
 $b.Add('- **Data leaving without visibility** — without sensitivity labels and DLP enforcement, sensitive data can be exfiltrated or shared externally without triggering an alert.')
 $b.Add('')
-$b.Add('The IBM Cost of a Data Breach 2024 report places the average breach cost at $4.88M globally ($9.36M in the United States). Organizations with a mature Zero Trust program average $1.76M less per breach than organizations without one.')
+$b.Add('The IBM Cost of a Data Breach 2024 report places the average breach cost at $4.88M globally ($9.36M in the United States). IBM''s 2021 report, the most recent edition to publish a Zero Trust-specific breakdown, found that organizations with a mature Zero Trust strategy averaged $3.28M per breach compared with $5.04M for organizations that had not deployed Zero Trust, a difference of $1.76M.')
 $b.Add('')
 $b.Add('---')
 $b.Add('')


### PR DESCRIPTION
## Problem

The generated board report and `Examples/Sample-Tenant-Report.md` both stated:

> "Organizations with a mature Zero Trust program average $1.76M less per breach than organizations without one."

and attributed it to the **IBM Cost of a Data Breach 2024** report. That report publishes **no Zero Trust-specific breakdown**. In the 2024 edition, **$1.76M is the additional cost borne by organizations with severe security staffing shortages** — an unrelated finding.

This text is emitted into **every generated client board report**, so the misattribution was shipping in real deliverables.

## Fix

The $1.76M Zero Trust figure is genuine, but it originates in **IBM 2021**: mature Zero Trust averaged **$3.28M** per breach versus **$5.04M** for organizations that had not deployed Zero Trust (a $1.76M / 42% difference; global average that year was $4.24M). IBM 2021 is the most recent edition to publish a Zero Trust-specific cut — 2022 reported a smaller delta (~$0.95M), and 2023/2024 dropped the breakdown in favor of AI/automation and staffing cuts.

Both files now:
- cite the **2021** edition explicitly and state both underlying figures ($3.28M vs $5.04M), and
- continue to source the current **$4.88M global / $9.36M US** averages from the **2024** report (those figures were correct).

## Validation

Regenerated the board report from the live collector export (`ZTRAResult-20260714-120542.json`) and confirmed the corrected sentence renders as intended.

Sources: [IBM 2021 press release](https://newsroom.ibm.com/2021-07-28-IBM-Report-Cost-of-a-Data-Breach-Hits-Record-High-During-Pandemic) (ZT figures), IBM Cost of a Data Breach 2024 (current averages; $1.76M = staffing shortage cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)