### PR TITLE
fix(ztra): refresh board report benchmarks to IBM Cost of a Data Breach 2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Refreshed the breach-cost benchmarks in the ZTRA board report output
+  (`Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Format-ZTReadinessReport.ps1`) and
+  `Examples/Sample-Tenant-Report.md` from the IBM Cost of a Data Breach 2024 report to the 2025
+  edition. The global average fell to $4.44M (from $4.88M, the first decrease in five years) while
+  the United States average rose to $10.22M (from $9.36M), an all-time high for any region. Added
+  the 2025 finding that phishing is the most common initial attack vector at 16% of breaches,
+  having overtaken compromised credentials. The Zero Trust comparison continues to cite IBM 2021,
+  confirmed against the 2025 report as the most recent edition to publish a Zero Trust-specific
+  breakdown (the 2025 edition contains no Zero Trust analysis); it is now expressed as a 35%
+  reduction alongside the underlying $3.28M and $5.04M figures.
 - Corrected a misattributed breach-cost statistic in the ZTRA board report output
   (`Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Format-ZTReadinessReport.ps1`) and in
   `Examples/Sample-Tenant-Report.md`. Both stated that "organizations with a mature Zero Trust

--- a/Frameworks/Zero-Trust-Readiness-Assessment/Examples/Sample-Tenant-Report.md
+++ b/Frameworks/Zero-Trust-Readiness-Assessment/Examples/Sample-Tenant-Report.md
@@ -283,11 +283,13 @@ credential theft are the top initial access vectors in M365 environments. Withou
 device CA policy and enforced MFA coverage set, an attacker who obtains a valid password can
 access corporate resources from any device.
 
-The IBM Cost of a Data Breach 2024 report places the average breach cost at $4.88M globally
-($9.36M in the United States). IBM's 2021 report, the most recent edition to publish a Zero
-Trust-specific breakdown, found that organizations with a mature Zero Trust strategy averaged
-$3.28M per breach compared with $5.04M for organizations that had not deployed Zero Trust, a
-difference of $1.76M. A Stage 2 organization typically falls into the higher-cost breach category.
+The IBM Cost of a Data Breach 2025 report places the average breach cost at $4.44M globally and
+$10.22M in the United States, an all-time high for any region. Phishing was the most common
+initial attack vector, accounting for 16% of breaches. IBM's 2021 report, the most recent edition
+to publish a Zero Trust-specific breakdown, found that organizations with a mature Zero Trust
+strategy averaged $3.28M per breach compared with $5.04M for organizations that had not deployed
+Zero Trust, a reduction of 35%. A Stage 2 organization typically falls into the higher-cost
+breach category.
 
 ---
 

--- a/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Format-ZTReadinessReport.ps1
+++ b/Frameworks/Zero-Trust-Readiness-Assessment/Scripts/Format-ZTReadinessReport.ps1
@@ -300,7 +300,7 @@ $b.Add('- **Credential attacks succeeding** — phishing, password spray, and MF
 $b.Add('- **Lateral movement going undetected** — without device compliance enforcement and endpoint telemetry, an attacker who gains access to one account can move freely.')
 $b.Add('- **Data leaving without visibility** — without sensitivity labels and DLP enforcement, sensitive data can be exfiltrated or shared externally without triggering an alert.')
 $b.Add('')
-$b.Add('The IBM Cost of a Data Breach 2024 report places the average breach cost at $4.88M globally ($9.36M in the United States). IBM''s 2021 report, the most recent edition to publish a Zero Trust-specific breakdown, found that organizations with a mature Zero Trust strategy averaged $3.28M per breach compared with $5.04M for organizations that had not deployed Zero Trust, a difference of $1.76M.')
+$b.Add('The IBM Cost of a Data Breach 2025 report places the average breach cost at $4.44M globally and $10.22M in the United States, an all-time high for any region. Phishing was the most common initial attack vector, accounting for 16% of breaches. IBM''s 2021 report, the most recent edition to publish a Zero Trust-specific breakdown, found that organizations with a mature Zero Trust strategy averaged $3.28M per breach compared with $5.04M for organizations that had not deployed Zero Trust, a reduction of 35%.')
 $b.Add('')
 $b.Add('---')
 $b.Add('')


### PR DESCRIPTION
Updates the generated board report and `Examples/Sample-Tenant-Report.md` from the IBM 2024 benchmarks to the **2025** edition, verified against the full report PDF.

## Figures updated

| Metric | Was (2024) | Now (2025) |
|---|---|---|
| Global average | $4.88M | **$4.44M** (first decrease in five years) |
| United States average | $9.36M | **$10.22M** (all-time high for any region) |

The US figure matters most for the client base: the global average fell while the **US rose 9% to a record**, so the prior text was both stale and the weaker framing for US audiences.

Also adds the 2025 finding that **phishing is the most common initial attack vector at 16% of breaches**, having overtaken compromised credentials — which supports the board report's existing credential-attack narrative from a primary source.

## Zero Trust comparison

Still cites **IBM 2021**, now confirmed directly against the 2025 report: the 2025 edition contains **no Zero Trust analysis whatsoever**, verifying 2021 as the most recent edition to publish a Zero Trust-specific breakdown. (This also disproves secondary sources that attribute the $1.76M ZT figure to 2024/2025 — their arithmetic never reconciled.)

Now expressed as a **35% reduction** alongside the underlying $3.28M vs $5.04M figures, which is the sounder way to carry a 2021 relative finding next to 2025 cost levels.

## Validation

Regenerated the board report from the live collector export (`ZTRAResult-20260714-120542.json`) and confirmed the text renders as intended.

Follows #119. Source: IBM Cost of a Data Breach 2025 full report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)